### PR TITLE
Add Has media to harmonised model

### DIFF
--- a/src/main/java/eu/dissco/core/translator/service/BioCaseService.java
+++ b/src/main/java/eu/dissco/core/translator/service/BioCaseService.java
@@ -191,7 +191,7 @@ public class BioCaseService implements WebClientService {
             physicalSpecimenId,
             termMapper.retrieveFromABCD(new Type(), unitAttributes),
             harmonizeAttributes(datasets, unitAttributes, physicalSpecimenIdType, organizationId),
-            unitAttributes
+            removeMultiMediaFields(unitAttributes)
         );
 
         log.debug("Result digital Specimen: {}", digitalSpecimen);
@@ -213,7 +213,6 @@ public class BioCaseService implements WebClientService {
   private ObjectNode parseToJson(Unit unit) throws DisscoEfgParsingException {
     var unitData = getData(mapper.valueToTree(unit));
     extractEfgInformation(unit, unitData);
-    removeMultiMediaFields(unitData);
     return unitData;
   }
 
@@ -338,14 +337,16 @@ public class BioCaseService implements WebClientService {
     unitData.remove("abcd:unitExtension");
   }
 
-  private void removeMultiMediaFields(ObjectNode unitData) {
+  private JsonNode removeMultiMediaFields(ObjectNode unitData) {
     var multiMediaFields = new ArrayList<String>();
-    unitData.fields().forEachRemaining(field -> {
+    var data = unitData.deepCopy();
+    data.fields().forEachRemaining(field -> {
       if (field.getKey().startsWith("abcd:multiMediaObjects")) {
         multiMediaFields.add(field.getKey());
       }
     });
-    unitData.remove(multiMediaFields);
+    data.remove(multiMediaFields);
+    return data;
   }
 
   private String getPhysicalSpecimenId(String physicalSpecimenIdType, String organizationId,

--- a/src/main/java/eu/dissco/core/translator/terms/TermMapper.java
+++ b/src/main/java/eu/dissco/core/translator/terms/TermMapper.java
@@ -12,6 +12,7 @@ import eu.dissco.core.translator.terms.specimen.ObjectType;
 import eu.dissco.core.translator.terms.specimen.PhysicalSpecimenCollection;
 import eu.dissco.core.translator.terms.specimen.SpecimenName;
 import eu.dissco.core.translator.terms.specimen.TypeStatus;
+import eu.dissco.core.translator.terms.specimen.HasMedia;
 import eu.dissco.core.translator.terms.specimen.location.Continent;
 import eu.dissco.core.translator.terms.specimen.location.Country;
 import eu.dissco.core.translator.terms.specimen.location.CountryCode;
@@ -67,6 +68,7 @@ public class TermMapper {
     list.add(new CollectingNumber());
     list.add(new Collector());
     list.add(new TypeStatus());
+    list.add(new HasMedia());
     list.addAll(locationTerms());
     return list;
   }

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/HasMedia.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/HasMedia.java
@@ -1,0 +1,39 @@
+package eu.dissco.core.translator.terms.specimen;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+import org.gbif.dwc.ArchiveFile;
+import org.gbif.dwc.record.Record;
+
+public class HasMedia extends Term {
+
+  public static final String TERM = ODS_PREFIX + "hasMedia";
+  private final List<String> dwcaTerms = List.of("dwc:associatedMedia");
+  private final List<String> abcdTerms = List.of("abcd:multiMediaObjects/multiMediaObject/0/fileURI");
+
+  @Override
+  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
+    var result = super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+    return toBoolean(result);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    var result = super.searchAbcdForTerm(unit, abcdTerms);
+    return toBoolean(result);
+  }
+
+  private static String toBoolean(String result) {
+    if (result != null){
+      return "true";
+    } else {
+      return "false";
+    }
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/HasMedia.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/HasMedia.java
@@ -25,11 +25,7 @@ public class HasMedia extends Term {
   }
 
   private static String toBoolean(String result) {
-    if (result != null){
-      return "true";
-    } else {
-      return "false";
-    }
+    return String.valueOf(result != null);
   }
 
   @Override

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/HasMediaTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/HasMediaTest.java
@@ -1,0 +1,63 @@
+package eu.dissco.core.translator.terms.specimen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.gbif.dwc.ArchiveField;
+import org.gbif.dwc.ArchiveFile;
+import org.gbif.dwc.record.Record;
+import org.gbif.dwc.terms.DwcTerm;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class HasMediaTest {
+
+  private static final String MEDIA_URL = "https://archimg.mnhn.lu/Collections/Collections/ZS536.JPG";
+
+  private final HasMedia hasMedia = new HasMedia();
+  @Mock
+  private ArchiveFile archiveFile;
+  @Mock
+  private Record rec;
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var archiveField = new ArchiveField(0, DwcTerm.associatedMedia);
+    given(archiveFile.getField("dwc:associatedMedia")).willReturn(archiveField);
+    given(rec.value(archiveField.getTerm())).willReturn(MEDIA_URL);
+
+    // When
+    var result = hasMedia.retrieveFromDWCA(archiveFile, rec);
+
+    // Then
+    assertThat(result).isEqualTo("true");
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("abcd:multiMediaObjects/multiMediaObject/0/fileURI", MEDIA_URL);
+
+    // When
+    var result = hasMedia.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo("true");
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = hasMedia.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(HasMedia.TERM);
+  }
+
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/HasMediaTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/HasMediaTest.java
@@ -52,6 +52,19 @@ class HasMediaTest {
   }
 
   @Test
+  void testRetrieveFromABCDNoMedia() {
+    // Given
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("", MEDIA_URL);
+
+    // When
+    var result = hasMedia.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo("false");
+  }
+
+  @Test
   void testGetTerm() {
     // When
     var result = hasMedia.getTerm();


### PR DESCRIPTION
First step to check for media.
Adds functionality for biocase and dwc where `dwc:associatedMedia` is used.
Support for dwc extensions for media is in a different [user story](https://naturalis.atlassian.net/browse/DD-301).
- https://github.com/tdwg/mids/issues/33
- https://naturalis.atlassian.net/browse/DD-180