### PR TITLE
Get abcd(efg) specimen based on preferred flag

### DIFF
--- a/src/main/java/eu/dissco/core/translator/terms/specimen/Collector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/Collector.java
@@ -3,6 +3,7 @@ package eu.dissco.core.translator.terms.specimen;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
 import org.gbif.dwc.ArchiveFile;
 import org.gbif.dwc.record.Record;
 
@@ -11,9 +12,9 @@ public class Collector extends Term {
   public static final String TERM = ODS_PREFIX + "collector";
 
   private final List<String> dwcaTerms = List.of("dwc:recordedBy", "dwc:recordedByID");
-  private final List<String> abcdTerms = List.of(
-      "abcd:gathering/agents/gatheringAgent/%s/person/fullName",
-      "abcd:gathering/agents/gatheringAgent/%s/person/agentText");
+  private final List<Pair<String, String>> abcdTerms = List.of(
+      Pair.of("abcd:gathering/agents/gatheringAgent/", "/person/fullName"),
+          Pair.of("abcd:gathering/agents/gatheringAgent/", "/person/agentText"));
 
   @Override
   public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
@@ -23,8 +24,8 @@ public class Collector extends Term {
   @Override
   public String retrieveFromABCD(JsonNode unit) {
     var value = combinePossibleValues(unit);
-    if (value == null){
-      if (unit.get("abcd:gathering/agents/gatheringAgentsText") != null){
+    if (value == null) {
+      if (unit.get("abcd:gathering/agents/gatheringAgentsText") != null) {
         return unit.get("abcd:gathering/agents/gatheringAgentsText").asText();
       } else {
         return null;
@@ -41,14 +42,14 @@ public class Collector extends Term {
     while (iterateOverElements) {
       String string = null;
       for (var abcdTerm : abcdTerms) {
-        var jsonValue = unit.get(String.format(abcdTerm, numberFound));
+        var jsonValue = unit.get(abcdTerm.getLeft() + numberFound + abcdTerm.getRight());
         if (jsonValue != null) {
           string = jsonValue.asText();
           break;
         }
       }
       if (string != null) {
-        if (numberFound == 0){
+        if (numberFound == 0) {
           builder.append(string);
         } else {
           builder.append(" | ").append(string);
@@ -58,7 +59,7 @@ public class Collector extends Term {
         iterateOverElements = false;
       }
     }
-    if (builder.length() != 0){
+    if (builder.length() != 0) {
       return builder.toString();
     } else {
       return null;

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/Modified.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/Modified.java
@@ -8,8 +8,8 @@ import org.gbif.dwc.record.Record;
 
 public class Modified extends Term {
 
-  public static final String TERM = ODS_PREFIX + "modified";
-  private final List<String> dwcaTerms = List.of("dcterms:modified");
+  public static final String TERM = "dcterms:modified";
+  private final List<String> dwcaTerms = List.of(TERM);
   private final List<String> abcdTerms = List.of("abcd:hasDateModified", "abcd:dateLastEdited");
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/SpecimenName.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/SpecimenName.java
@@ -36,9 +36,8 @@ public class SpecimenName extends Term {
   }
 
   private String getSpecimenName(JsonNode unit, Pair<String, String> term) {
-    var iterateOverElements = true;
     var numberFound = 0;
-    while (iterateOverElements) {
+    while (true) {
       if (unit.get(String.format(term.getLeft(), numberFound)) != null) {
         var preffered = unit.get(String.format(term.getLeft(), numberFound)).asBoolean();
         if (preffered) {
@@ -49,14 +48,17 @@ public class SpecimenName extends Term {
           numberFound++;
         }
       } else {
-        if (unit.get(String.format(term.getRight(), 0)) != null) {
-          return unit.get(String.format(term.getRight(), 0)).asText();
-        } else {
-          iterateOverElements = false;
-        }
+        return getFirstName(unit, term);
       }
     }
-    return null;
+  }
+
+  private String getFirstName(JsonNode unit, Pair<String, String> term) {
+    if (unit.get(String.format(term.getRight(), 0)) != null) {
+      return unit.get(String.format(term.getRight(), 0)).asText();
+    } else {
+      return null;
+    }
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/SpecimenName.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/SpecimenName.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.gbif.dwc.ArchiveFile;
 import org.gbif.dwc.record.Record;
 
@@ -12,10 +13,13 @@ public class SpecimenName extends Term {
 
   public static final String TERM = ODS_PREFIX + "specimenName";
   private final List<String> dwcaTerms = List.of("dwc:scientificName");
-  private final List<String> abcdefgTerms = List.of(
-      "abcd:identifications/identification/0/result/taxonIdentified/scientificName/fullScientificNameString",
-      "abcd-efg:identifications/identification/0/result/mineralRockIdentified/classifiedName/fullScientificNameString"
-  );
+  private final Pair<String, String> abcdTerm = Pair.of(
+      "abcd:identifications/identification/%s/preferredFlag",
+      "abcd:identifications/identification/%s/result/taxonIdentified/scientificName/fullScientificNameString");
+
+  private final Pair<String, String> abcdefgTerm = Pair.of(
+      "abcd-efg:identifications/identification/%s/preferredFlag",
+      "abcd-efg:identifications/identification/%s/result/mineralRockIdentified/classifiedName/fullScientificNameString");
 
   @Override
   public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
@@ -24,7 +28,35 @@ public class SpecimenName extends Term {
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdefgTerms);
+    var result = getSpecimenName(unit, abcdTerm);
+    if (result == null){
+      result = getSpecimenName(unit, abcdefgTerm);
+    }
+    return result;
+  }
+
+  private String getSpecimenName(JsonNode unit, Pair<String, String> term) {
+    var iterateOverElements = true;
+    var numberFound = 0;
+    while (iterateOverElements) {
+      if (unit.get(String.format(term.getLeft(), numberFound)) != null) {
+        var preffered = unit.get(String.format(term.getLeft(), numberFound)).asBoolean();
+        if (preffered) {
+          if (unit.get(String.format(term.getRight(), numberFound)) != null) {
+            return unit.get(String.format(term.getRight(), numberFound)).asText();
+          }
+        } else {
+          numberFound++;
+        }
+      } else {
+        if (unit.get(String.format(term.getRight(), 0)) != null) {
+          return unit.get(String.format(term.getRight(), 0)).asText();
+        } else {
+          iterateOverElements = false;
+        }
+      }
+    }
+    return null;
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/AbstractChronoStratigraphy.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/AbstractChronoStratigraphy.java
@@ -4,26 +4,32 @@ import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 
 @Slf4j
 public abstract class AbstractChronoStratigraphy extends Term {
 
-  private static final String ABCD_DIVISION =
-      "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/chronostratigraphicAttributions/chronostratigraphicAttribution/%s/chronoStratigraphicDivision";
-  private static final String ABCD_VALUE =
-      "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/chronostratigraphicAttributions/chronostratigraphicAttribution/%s/chronostratigraphicName";
+  private static final Pair<String, String> ABCD_DIVISION =
+      Pair.of(
+          "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/chronostratigraphicAttributions/chronostratigraphicAttribution/",
+          "/chronoStratigraphicDivision");
+  private static final Pair<String, String> ABCD_VALUE =
+      Pair.of(
+          "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/chronostratigraphicAttributions/chronostratigraphicAttribution/",
+          "/chronostratigraphicName");
 
   protected String searchABCDChronostratigraphy(JsonNode unit, List<String> divisionSearched) {
     for (var divisionSearch : divisionSearched) {
       var iterateOverElements = true;
       var numberFound = 0;
       while (iterateOverElements) {
-        var divisionNode = unit.get(String.format(ABCD_DIVISION, numberFound));
+        var divisionNode = unit.get(
+            ABCD_DIVISION.getLeft() + numberFound + ABCD_DIVISION.getRight());
         if (divisionNode != null) {
           var division = divisionNode.asText();
           if (division.equalsIgnoreCase(divisionSearch)
-              && unit.get(String.format(ABCD_VALUE, numberFound)) != null) {
-            return unit.get(String.format(ABCD_VALUE, numberFound)).asText();
+              && unit.get(ABCD_VALUE.getLeft() + numberFound + ABCD_VALUE.getRight()) != null) {
+            return unit.get(ABCD_VALUE.getLeft() + numberFound + ABCD_VALUE.getRight()).asText();
           }
           numberFound++;
         } else {

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/SpecimenNameTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/SpecimenNameTest.java
@@ -39,7 +39,7 @@ class SpecimenNameTest {
   }
 
   @Test
-  void testRetrieveFromABCD() {
+  void testRetrieveFromABCDEFG() {
     // Given
     var specimenNameString = "SpecimenName";
     var unit = new ObjectMapper().createObjectNode();
@@ -53,6 +53,59 @@ class SpecimenNameTest {
     // Then
     assertThat(result).isEqualTo(specimenNameString);
   }
+
+  @Test
+  void testRetrieveFromABCDWithPreferred() {
+    // Given
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put(
+        "abcd:identifications/identification/0/preferredFlag", false);
+    unit.put("abcd:identifications/identification/0/result/taxonIdentified/scientificName/fullScientificNameString",
+        "Arrabidaea chica (Humb. & Bonpl.) B.Verl.");
+    unit.put(
+        "abcd:identifications/identification/1/preferredFlag", true);
+    unit.put("abcd:identifications/identification/1/result/taxonIdentified/scientificName/fullScientificNameString",
+        "Bignonia chica Humb. & Bonpl.");
+    unit.put(
+        "abcd:identifications/identification/2/preferredFlag", false);
+    unit.put("abcd:identifications/identification/2/result/taxonIdentified/scientificName/fullScientificNameString",
+        "Arrabidaea chica var. thyrsoidea Bureau");
+
+    // When
+    var result = specimenName.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo("Bignonia chica Humb. & Bonpl.");
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var specimenNameString = "SpecimenName";
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put(
+        "abcd:identifications/identification/0/result/taxonIdentified/scientificName/fullScientificNameString",
+        specimenNameString);
+
+    // When
+    var result = specimenName.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(specimenNameString);
+  }
+
+  @Test
+  void testRetrieveFromABCDNotPresent() {
+    // Given
+    var unit = new ObjectMapper().createObjectNode();
+
+    // When
+    var result = specimenName.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isNull();
+  }
+
 
   @Test
   void testGetTerm() {


### PR DESCRIPTION
Correct the specimen name for abcd and abcdefg.
Before it just looked at the first name in the list.
However, in abcd(efg) there could be more specimen identifications, the preferred on is indicated by the preferredFlag.
The flag may not always be present though.
The code now checks for a prefferedFlag and uses this. When no flag can be found it uses the first.
https://naturalis.atlassian.net/browse/DD-303