### PR TITLE
Change DWCA ingestion to add extensions

### DIFF
--- a/src/main/java/eu/dissco/core/translator/database/jooq/DefaultCatalog.java
+++ b/src/main/java/eu/dissco/core/translator/database/jooq/DefaultCatalog.java
@@ -6,7 +6,6 @@ package eu.dissco.core.translator.database.jooq;
 
 import java.util.Arrays;
 import java.util.List;
-
 import org.jooq.Schema;
 import org.jooq.impl.CatalogImpl;
 

--- a/src/main/java/eu/dissco/core/translator/database/jooq/Keys.java
+++ b/src/main/java/eu/dissco/core/translator/database/jooq/Keys.java
@@ -8,7 +8,6 @@ import eu.dissco.core.translator.database.jooq.tables.NewMapping;
 import eu.dissco.core.translator.database.jooq.tables.NewSourceSystem;
 import eu.dissco.core.translator.database.jooq.tables.records.NewMappingRecord;
 import eu.dissco.core.translator.database.jooq.tables.records.NewSourceSystemRecord;
-
 import org.jooq.TableField;
 import org.jooq.UniqueKey;
 import org.jooq.impl.DSL;

--- a/src/main/java/eu/dissco/core/translator/database/jooq/Public.java
+++ b/src/main/java/eu/dissco/core/translator/database/jooq/Public.java
@@ -6,10 +6,8 @@ package eu.dissco.core.translator.database.jooq;
 
 import eu.dissco.core.translator.database.jooq.tables.NewMapping;
 import eu.dissco.core.translator.database.jooq.tables.NewSourceSystem;
-
 import java.util.Arrays;
 import java.util.List;
-
 import org.jooq.Catalog;
 import org.jooq.Table;
 import org.jooq.impl.SchemaImpl;

--- a/src/main/java/eu/dissco/core/translator/database/jooq/tables/NewMapping.java
+++ b/src/main/java/eu/dissco/core/translator/database/jooq/tables/NewMapping.java
@@ -7,11 +7,9 @@ package eu.dissco.core.translator.database.jooq.tables;
 import eu.dissco.core.translator.database.jooq.Keys;
 import eu.dissco.core.translator.database.jooq.Public;
 import eu.dissco.core.translator.database.jooq.tables.records.NewMappingRecord;
-
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
-
 import org.jooq.Field;
 import org.jooq.ForeignKey;
 import org.jooq.JSONB;

--- a/src/main/java/eu/dissco/core/translator/database/jooq/tables/NewSourceSystem.java
+++ b/src/main/java/eu/dissco/core/translator/database/jooq/tables/NewSourceSystem.java
@@ -7,11 +7,9 @@ package eu.dissco.core.translator.database.jooq.tables;
 import eu.dissco.core.translator.database.jooq.Keys;
 import eu.dissco.core.translator.database.jooq.Public;
 import eu.dissco.core.translator.database.jooq.tables.records.NewSourceSystemRecord;
-
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
-
 import org.jooq.Field;
 import org.jooq.ForeignKey;
 import org.jooq.Name;

--- a/src/main/java/eu/dissco/core/translator/database/jooq/tables/records/NewMappingRecord.java
+++ b/src/main/java/eu/dissco/core/translator/database/jooq/tables/records/NewMappingRecord.java
@@ -5,9 +5,7 @@ package eu.dissco.core.translator.database.jooq.tables.records;
 
 
 import eu.dissco.core.translator.database.jooq.tables.NewMapping;
-
 import java.time.Instant;
-
 import org.jooq.Field;
 import org.jooq.JSONB;
 import org.jooq.Record2;

--- a/src/main/java/eu/dissco/core/translator/database/jooq/tables/records/NewSourceSystemRecord.java
+++ b/src/main/java/eu/dissco/core/translator/database/jooq/tables/records/NewSourceSystemRecord.java
@@ -5,9 +5,7 @@ package eu.dissco.core.translator.database.jooq.tables.records;
 
 
 import eu.dissco.core.translator.database.jooq.tables.NewSourceSystem;
-
 import java.time.Instant;
-
 import org.jooq.Field;
 import org.jooq.Record1;
 import org.jooq.Record7;

--- a/src/main/java/eu/dissco/core/translator/exception/DiSSCoDataException.java
+++ b/src/main/java/eu/dissco/core/translator/exception/DiSSCoDataException.java
@@ -1,0 +1,8 @@
+package eu.dissco.core.translator.exception;
+
+public class DiSSCoDataException extends Exception{
+
+  public DiSSCoDataException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/exception/OrganizationNotRorId.java
+++ b/src/main/java/eu/dissco/core/translator/exception/OrganizationNotRorId.java
@@ -1,0 +1,8 @@
+package eu.dissco.core.translator.exception;
+
+public class OrganizationNotRorId extends DiSSCoDataException {
+
+  public OrganizationNotRorId(String s) {
+    super(s);
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/exception/UnknownPhysicalSpecimenIdType.java
+++ b/src/main/java/eu/dissco/core/translator/exception/UnknownPhysicalSpecimenIdType.java
@@ -1,0 +1,9 @@
+package eu.dissco.core.translator.exception;
+
+public class UnknownPhysicalSpecimenIdType extends
+    DiSSCoDataException {
+
+  public UnknownPhysicalSpecimenIdType(String s) {
+    super(s);
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/repository/DwcaRepository.java
+++ b/src/main/java/eu/dissco/core/translator/repository/DwcaRepository.java
@@ -1,0 +1,85 @@
+package eu.dissco.core.translator.repository;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.tuple.Pair;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.JSONB;
+import org.jooq.Query;
+import org.jooq.Record;
+import org.jooq.Table;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DwcaRepository {
+
+  private final Field<String> idField = DSL.field("dwcaid", String.class);
+  private final Field<JSONB> dataField = DSL.field("data", JSONB.class);
+
+  private final ObjectMapper mapper;
+  private final DSLContext context;
+
+  public void createTable(String tableName) {
+    context.createTable(tableName)
+        .column(idField, SQLDataType.VARCHAR)
+        .column(dataField, SQLDataType.JSONB)
+        .execute();
+    context.createIndex().on(tableName, idField.getName()).execute();
+  }
+
+
+  private Table<Record> getTable(String tableName) {
+    return DSL.table("\"" + tableName + "\"");
+  }
+
+  public void postRecords(String tableName, List<Pair<String, JsonNode>> dbRecords) {
+    var queries = dbRecords.stream().map(dbRecord -> recordToQuery(tableName, dbRecord)).toList();
+    context.batch(queries).execute();
+  }
+
+  private Query recordToQuery(String tableName, Pair<String, JsonNode> dbRecord) {
+    try {
+      return context.insertInto(getTable(tableName)).set(idField, dbRecord.getLeft())
+          .set(dataField, JSONB.jsonb(mapper.writeValueAsString(dbRecord.getRight())));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void deleteTable(String tableName) {
+    context.dropTableIfExists(tableName).execute();
+  }
+
+  public Map<String, ObjectNode> getCoreRecords(List<String> batch, String tableName) {
+    return context.selectFrom(getTable(tableName)).where(idField.in(batch)).fetchMap(
+        dbRecord -> dbRecord.get(idField), this::getNode);
+  }
+
+  private ObjectNode getNode(Record dbRecord) {
+    try {
+      return mapper.readValue(dbRecord.get(dataField).data(), ObjectNode.class);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public Map<String, List<ObjectNode>> getRecords(List<String> batch, String tableName) {
+    return context.selectFrom(getTable(tableName)).where(idField.in(batch))
+        .stream().collect(groupingBy(dbRecord -> dbRecord.get(idField), mapping(this::getNode, toList())));
+  }
+
+}
+

--- a/src/main/java/eu/dissco/core/translator/service/DwcaService.java
+++ b/src/main/java/eu/dissco/core/translator/service/DwcaService.java
@@ -239,8 +239,11 @@ public class DwcaService implements WebClientService {
   }
 
   private JsonNode removeMedia(JsonNode fullRecord) {
-    ObjectNode originalData = fullRecord.deepCopy();
-    originalData.remove(List.of(GBIF_MULTIMEDIA, AC_MULTIMEDIA));
+    var originalData = fullRecord.deepCopy();
+    ObjectNode extensions = (ObjectNode) originalData.get(EXTENSIONS);
+    if (extensions != null){
+      extensions.remove(List.of(GBIF_MULTIMEDIA, AC_MULTIMEDIA));
+    }
     return originalData;
   }
 

--- a/src/main/java/eu/dissco/core/translator/service/IngestionUtility.java
+++ b/src/main/java/eu/dissco/core/translator/service/IngestionUtility.java
@@ -1,0 +1,34 @@
+package eu.dissco.core.translator.service;
+
+import eu.dissco.core.translator.exception.DiSSCoDataException;
+import eu.dissco.core.translator.exception.OrganizationNotRorId;
+import eu.dissco.core.translator.exception.UnknownPhysicalSpecimenIdType;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class IngestionUtility {
+
+  private IngestionUtility() {
+    // Utility class
+  }
+
+  public static String getPhysicalSpecimenId(String physicalSpecimenIdType, String organizationId,
+      String physicalSpecimenId) throws DiSSCoDataException {
+    if (physicalSpecimenIdType.equals("cetaf")) {
+      return physicalSpecimenId;
+    } else if (physicalSpecimenIdType.equals("combined")) {
+      return physicalSpecimenId + ":" + minifyOrganizationId(organizationId);
+    } else {
+      log.warn("Unknown physicalSpecimenIdType specified");
+      throw new UnknownPhysicalSpecimenIdType(physicalSpecimenIdType + " is not a known id type");
+    }
+  }
+
+  private static String minifyOrganizationId(String organizationId) throws OrganizationNotRorId {
+    if (organizationId.startsWith("https://ror.org")) {
+      return organizationId.replace("https://ror.org/", "");
+    } else {
+      throw new OrganizationNotRorId(organizationId + " is not a valid ror");
+    }
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/service/KafkaService.java
+++ b/src/main/java/eu/dissco/core/translator/service/KafkaService.java
@@ -1,6 +1,5 @@
 package eu.dissco.core.translator.service;
 
-import eu.dissco.core.translator.properties.KafkaProperties;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;

--- a/src/main/java/eu/dissco/core/translator/terms/License.java
+++ b/src/main/java/eu/dissco/core/translator/terms/License.java
@@ -1,10 +1,9 @@
 package eu.dissco.core.translator.terms;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import efg.DataSets.DataSet;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 @Slf4j
 public class License extends Term {
@@ -13,8 +12,8 @@ public class License extends Term {
   private final List<String> dwcaTerms = List.of(TERM, "dc:license");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/Term.java
+++ b/src/main/java/eu/dissco/core/translator/terms/Term.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import efg.DataSets.DataSet;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 @Slf4j
 public abstract class Term {
@@ -14,28 +12,10 @@ public abstract class Term {
   protected static final String ODS_PREFIX = "ods:";
   protected static final String DWC_PREFIX = "dwc:";
 
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    log.info("No specific attributes retrieve specified for term: {}", getTerm());
-    return "";
-  }
-
-  protected String searchDWCAForTerm(ArchiveFile archiveFile, Record rec,
-      List<String> originalTerms) {
+  protected String searchJsonForTerm(JsonNode attributes, List<String> originalTerms) {
     for (var originalTerm : originalTerms) {
-      if (archiveFile.getField(originalTerm) != null) {
-        var value = rec.value(archiveFile.getField(originalTerm).getTerm());
-        if (value != null) {
-          return value;
-        }
-      }
-    }
-    log.debug("Term not found in any of these search fields: {}", originalTerms);
-    return null;
-  }
-
-  protected String searchAbcdForTerm(JsonNode attributes, List<String> originalTerms) {
-    for (var originalTerm : originalTerms) {
-      if (attributes.get(originalTerm) != null) {
+      var valueNode = attributes.get(originalTerm);
+      if (valueNode != null && valueNode.isTextual()) {
         return attributes.get(originalTerm).asText();
       }
     }
@@ -68,6 +48,11 @@ public abstract class Term {
   }
 
   public String retrieveFromABCD(DataSet datasets) {
+    log.debug("No specific attributes retrieve specified for field: {}", getTerm());
+    return null;
+  }
+
+  public String retrieveFromDWCA(JsonNode unit) {
     log.debug("No specific attributes retrieve specified for field: {}", getTerm());
     return null;
   }

--- a/src/main/java/eu/dissco/core/translator/terms/Term.java
+++ b/src/main/java/eu/dissco/core/translator/terms/Term.java
@@ -9,6 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class Term {
 
+  private static final String MESSAGE = "No specific attributes retrieve specified for field: {}";
+
   protected static final String ODS_PREFIX = "ods:";
   protected static final String DWC_PREFIX = "dwc:";
 
@@ -43,17 +45,17 @@ public abstract class Term {
   public abstract String getTerm();
 
   public String retrieveFromABCD(JsonNode unit) {
-    log.debug("No specific attributes retrieve specified for field: {}", getTerm());
+    log.debug(MESSAGE, getTerm());
     return null;
   }
 
   public String retrieveFromABCD(DataSet datasets) {
-    log.debug("No specific attributes retrieve specified for field: {}", getTerm());
+    log.debug(MESSAGE, getTerm());
     return null;
   }
 
   public String retrieveFromDWCA(JsonNode unit) {
-    log.debug("No specific attributes retrieve specified for field: {}", getTerm());
+    log.debug(MESSAGE, getTerm());
     return null;
   }
 }

--- a/src/main/java/eu/dissco/core/translator/terms/TermMapper.java
+++ b/src/main/java/eu/dissco/core/translator/terms/TermMapper.java
@@ -7,12 +7,12 @@ import eu.dissco.core.translator.terms.specimen.CollectingNumber;
 import eu.dissco.core.translator.terms.specimen.Collector;
 import eu.dissco.core.translator.terms.specimen.DatasetId;
 import eu.dissco.core.translator.terms.specimen.DateCollected;
+import eu.dissco.core.translator.terms.specimen.HasMedia;
 import eu.dissco.core.translator.terms.specimen.Modified;
 import eu.dissco.core.translator.terms.specimen.ObjectType;
 import eu.dissco.core.translator.terms.specimen.PhysicalSpecimenCollection;
 import eu.dissco.core.translator.terms.specimen.SpecimenName;
 import eu.dissco.core.translator.terms.specimen.TypeStatus;
-import eu.dissco.core.translator.terms.specimen.HasMedia;
 import eu.dissco.core.translator.terms.specimen.location.Continent;
 import eu.dissco.core.translator.terms.specimen.location.Country;
 import eu.dissco.core.translator.terms.specimen.location.CountryCode;
@@ -45,8 +45,6 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -121,16 +119,17 @@ public class TermMapper {
     return terms;
   }
 
-  public String retrieveFromDWCA(Term term, ArchiveFile archiveFile, Record rec) {
-    var harmonisedTerm = term.getTerm();
-    if (mapping.getDefaultMappings().containsKey(harmonisedTerm)) {
-      return mapping.getDefaultMappings().get(harmonisedTerm);
+  public String retrieveFromDWCA(Term term, JsonNode unit) {
+    var termName = term.getTerm();
+    if (mapping.getDefaultMappings().containsKey(termName)) {
+      return mapping.getDefaultMappings().get(termName);
+    } else if (mapping.getFieldMappings().containsKey(termName)) {
+      var value = unit.get(mapping.getFieldMappings().get(termName));
+      if (value != null && value.isTextual()) {
+        return value.asText();
+      }
     }
-    if (mapping.getFieldMappings().containsKey(harmonisedTerm)) {
-      return rec.value(
-          archiveFile.getField(mapping.getFieldMappings().get(harmonisedTerm)).getTerm());
-    }
-    return term.retrieveFromDWCA(archiveFile, rec);
+    return term.retrieveFromDWCA(unit);
   }
 
   public String retrieveFromABCD(Term term, JsonNode unit) {

--- a/src/main/java/eu/dissco/core/translator/terms/media/AccessUri.java
+++ b/src/main/java/eu/dissco/core/translator/terms/media/AccessUri.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.media;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class AccessUri extends Term {
 
@@ -13,13 +11,13 @@ public class AccessUri extends Term {
   private final List<String> abcdTerms = List.of("abcd:fileURI");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/media/Format.java
+++ b/src/main/java/eu/dissco/core/translator/terms/media/Format.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 @Slf4j
 public class Format extends Term {
@@ -14,15 +12,14 @@ public class Format extends Term {
   private final List<String> dwcaTerms = List.of(TERM, "dc:format");
   private final List<String> abcdTerms = List.of("abcd:format");
 
-
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/media/MediaType.java
+++ b/src/main/java/eu/dissco/core/translator/terms/media/MediaType.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 @Slf4j
 public class MediaType extends Term {
@@ -15,13 +13,14 @@ public class MediaType extends Term {
 
   private final List<String> dwcaTerms = List.of(TERM, "dc:type");
   private final List<String> imageFormats = List.of("IMAGE/JPG", "JPG", "IMAGE/JPEG",
-      "JPEG", "IMAGE/PNG", "PNG");
+      "JPEG", "IMAGE/PNG", "PNG", "IMAGE/TIF", "TIF");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    var recoveredType = super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    var recoveredType = super.searchJsonForTerm(unit, dwcaTerms);
     if (recoveredType == null) {
-      return checkFormat(archiveFile, rec);
+      var format = new Format().retrieveFromDWCA(unit);
+      return checkFormat(format);
     } else {
       return parseToOdsType(recoveredType);
     }
@@ -60,10 +59,9 @@ public class MediaType extends Term {
     return null;
   }
 
-  private String checkFormat(ArchiveFile archiveFile, Record rec) {
-    var format = new Format().retrieveFromDWCA(archiveFile, rec);
+  private String checkFormat(String format) {
     if (format != null) {
-      if (format.startsWith("image")) {
+      if (imageFormats.contains(format) || format.startsWith("image")) {
         return IMAGE_OBJECT;
       }
       if (format.startsWith("audio")) {

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/CollectingNumber.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/CollectingNumber.java
@@ -3,24 +3,23 @@ package eu.dissco.core.translator.terms.specimen;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class CollectingNumber extends Term {
 
   public static final String TERM = ODS_PREFIX + "collectingNumber";
 
   private final List<String> dwcaTerms = List.of("dwc:recordNumber");
-  private final List<String> abcdTerms = List.of("abcd:collectorsFieldNumber", "abcd:gathering/code");
+  private final List<String> abcdTerms = List.of("abcd:collectorsFieldNumber",
+      "abcd:gathering/code");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/Collector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/Collector.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class Collector extends Term {
 
@@ -14,11 +12,11 @@ public class Collector extends Term {
   private final List<String> dwcaTerms = List.of("dwc:recordedBy", "dwc:recordedByID");
   private final List<Pair<String, String>> abcdTerms = List.of(
       Pair.of("abcd:gathering/agents/gatheringAgent/", "/person/fullName"),
-          Pair.of("abcd:gathering/agents/gatheringAgent/", "/person/agentText"));
+      Pair.of("abcd:gathering/agents/gatheringAgent/", "/person/agentText"));
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/DatasetId.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/DatasetId.java
@@ -1,9 +1,8 @@
 package eu.dissco.core.translator.terms.specimen;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class DatasetId extends Term {
 
@@ -12,8 +11,8 @@ public class DatasetId extends Term {
   private final List<String> dwcaTerms = List.of("dwc:datasetID");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/DateCollected.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/DateCollected.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class DateCollected extends Term {
 
@@ -15,13 +13,13 @@ public class DateCollected extends Term {
       "abcd:gathering/dateTime/isodateTimeEnd", "abcd:gathering/dateTime/dateText");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/HasMedia.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/HasMedia.java
@@ -15,12 +15,13 @@ public class HasMedia extends Term {
     var result = super.searchJsonForTerm(unit, dwcaTerms);
     if (result != null){
       return String.valueOf(true);
-    } else{
-      var gbifExtension = unit.get("gbif:Multimedia");
+    } else if (unit.get("extensions") != null){
+      var extensions = unit.get("extensions");
+      var gbifExtension = extensions.get("gbif:Multimedia");
       if (gbifExtension != null && gbifExtension.size() > 0){
         return String.valueOf(true);
       }
-      var acExtension = unit.get("ac:Multimedia");
+      var acExtension = extensions.get("http://rs.tdwg.org/ac/terms/Multimedia");
       if (acExtension != null && acExtension.size() > 0){
         return String.valueOf(true);
       }

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/HasMedia.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/HasMedia.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class HasMedia extends Term {
 
@@ -13,14 +11,26 @@ public class HasMedia extends Term {
   private final List<String> abcdTerms = List.of("abcd:multiMediaObjects/multiMediaObject/0/fileURI");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    var result = super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
-    return toBoolean(result);
+  public String retrieveFromDWCA(JsonNode unit) {
+    var result = super.searchJsonForTerm(unit, dwcaTerms);
+    if (result != null){
+      return String.valueOf(true);
+    } else{
+      var gbifExtension = unit.get("gbif:Multimedia");
+      if (gbifExtension != null && gbifExtension.size() > 0){
+        return String.valueOf(true);
+      }
+      var acExtension = unit.get("ac:Multimedia");
+      if (acExtension != null && acExtension.size() > 0){
+        return String.valueOf(true);
+      }
+    }
+    return String.valueOf(false);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    var result = super.searchAbcdForTerm(unit, abcdTerms);
+    var result = super.searchJsonForTerm(unit, abcdTerms);
     return toBoolean(result);
   }
 

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/Modified.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/Modified.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class Modified extends Term {
 
@@ -13,13 +11,13 @@ public class Modified extends Term {
   private final List<String> abcdTerms = List.of("abcd:hasDateModified", "abcd:dateLastEdited");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/ObjectType.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/ObjectType.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class ObjectType extends Term {
 
@@ -13,13 +11,13 @@ public class ObjectType extends Term {
   private final List<String> abcdTerms = List.of("abcd:kindOfUnit/0/value");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenCollection.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenCollection.java
@@ -1,9 +1,8 @@
 package eu.dissco.core.translator.terms.specimen;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class PhysicalSpecimenCollection extends Term {
 
@@ -12,8 +11,8 @@ public class PhysicalSpecimenCollection extends Term {
   private final List<String> dwcaTerms = List.of("dwc:collectionID", "dwc:collectionCode");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenId.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenId.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class PhysicalSpecimenId extends Term {
   public static final String TERM = ODS_PREFIX + "physicalSpecimenId";
@@ -13,13 +11,13 @@ public class PhysicalSpecimenId extends Term {
   private final List<String> abcdTerms = List.of("abcd:unitID");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/SpecimenName.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/SpecimenName.java
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 @Slf4j
 public class SpecimenName extends Term {
@@ -24,8 +22,8 @@ public class SpecimenName extends Term {
   );
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/TypeStatus.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/TypeStatus.java
@@ -16,11 +16,23 @@ public class TypeStatus extends Term {
           "abcd:specimenUnit/nomenclaturalTypeDesignations/nomenclaturalTypeDesignation/0/typeStatus",
           "abcd:specimenUnit/nomenclaturalTypeDesignations/nomenclaturalTypeDesignation/0/typifiedName/fullScientificNameString",
           "abcd:specimenUnit/nomenclaturalTypeDesignations/nomenclaturalTypeDesignation/0/nomenclaturalReference/titleCitation"
-          );
+      );
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    var result = super.searchJsonForTerm(unit, dwcaTerms);
+    if (result != null) {
+      return result;
+    } else {
+      var extensions = unit.get("extensions");
+      if (extensions != null) {
+        var identification = extensions.get("dwc:Identification");
+        if (identification.size() == 1) {
+          return searchJsonForTerm(identification.get(0), dwcaTerms);
+        }
+      }
+    }
+    return null;
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/TypeStatus.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/TypeStatus.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class TypeStatus extends Term {
 
@@ -21,8 +19,8 @@ public class TypeStatus extends Term {
           );
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/TypeStatus.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/TypeStatus.java
@@ -27,7 +27,7 @@ public class TypeStatus extends Term {
       var extensions = unit.get("extensions");
       if (extensions != null) {
         var identification = extensions.get("dwc:Identification");
-        if (identification.size() == 1) {
+        if (identification!= null && identification.size() == 1) {
           return searchJsonForTerm(identification.get(0), dwcaTerms);
         }
       }

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/Continent.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/Continent.java
@@ -1,9 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class Continent extends Term {
 
@@ -11,8 +10,8 @@ public class Continent extends Term {
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/Country.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/Country.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen.location;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class Country extends Term {
 
@@ -16,13 +14,13 @@ public class Country extends Term {
       "abcd:gathering/country/nameDerived/value");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/CountryCode.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/CountryCode.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen.location;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class CountryCode extends Term {
 
@@ -15,13 +13,13 @@ public class CountryCode extends Term {
       "abcd:gathering/country/iso3166Code");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/County.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/County.java
@@ -1,9 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class County extends Term {
 
@@ -11,8 +10,8 @@ public class County extends Term {
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/DecimalLatitude.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/DecimalLatitude.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen.location;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class DecimalLatitude extends Term {
 
@@ -15,13 +13,13 @@ public class DecimalLatitude extends Term {
       "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/latitudeDecimal");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/DecimalLongitude.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/DecimalLongitude.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen.location;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class DecimalLongitude extends Term {
 
@@ -15,13 +13,13 @@ public class DecimalLongitude extends Term {
       "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/longitudeDecimal");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/GeodeticDatum.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/GeodeticDatum.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen.location;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class GeodeticDatum extends Term {
 
@@ -15,13 +13,13 @@ public class GeodeticDatum extends Term {
       "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/spatialDatum");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/Island.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/Island.java
@@ -1,17 +1,16 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class Island extends Term {
   public static final String TERM = DWC_PREFIX + "island";
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/IslandGroup.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/IslandGroup.java
@@ -1,17 +1,16 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class IslandGroup extends Term {
   public static final String TERM = DWC_PREFIX + "islandGroup";
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/Locality.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/Locality.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen.location;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class Locality extends Term {
   public static final String TERM = DWC_PREFIX + "locality";
@@ -13,13 +11,13 @@ public class Locality extends Term {
   private final List<String> abcdTerms = List.of("abcd:gathering/localityText/value");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/Municipality.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/Municipality.java
@@ -1,17 +1,16 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class Municipality extends Term {
   public static final String TERM = DWC_PREFIX + "municipality";
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/StateProvince.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/StateProvince.java
@@ -1,9 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class StateProvince extends Term {
 
@@ -11,8 +10,8 @@ public class StateProvince extends Term {
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/WaterBody.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/WaterBody.java
@@ -1,9 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class WaterBody extends Term {
 
@@ -11,8 +10,8 @@ public class WaterBody extends Term {
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/biostratigraphic/HighestBiostratigraphicZone.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/biostratigraphic/HighestBiostratigraphicZone.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.biostratigraphic;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class HighestBiostratigraphicZone extends Term {
 
@@ -17,8 +15,8 @@ public class HighestBiostratigraphicZone extends Term {
       "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/biostratigraphicAttributionsType/biostratigraphicAttribution/0/fossilSubzoneName");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/biostratigraphic/LowestBiostratigraphicZone.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/biostratigraphic/LowestBiostratigraphicZone.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.biostratigraphic;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class LowestBiostratigraphicZone extends Term {
 
@@ -17,8 +15,8 @@ public class LowestBiostratigraphicZone extends Term {
       "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/biostratigraphicAttributionsType/biostratigraphicAttribution/0/fossilSubzoneName");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestAgeOrLowestStage.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestAgeOrLowestStage.java
@@ -2,18 +2,15 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphi
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class EarliestAgeOrLowestStage extends AbstractChronoStratigraphy {
 
   public static final String TERM = DWC_PREFIX + "earliestAgeOrLowestStage";
   private final List<String> dwcaTerms = List.of(TERM);
 
-
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestEonOrLowestEonothem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestEonOrLowestEonothem.java
@@ -2,18 +2,15 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphi
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class EarliestEonOrLowestEonothem extends AbstractChronoStratigraphy {
 
   public static final String TERM = DWC_PREFIX + "earliestEonOrLowestEonothem";
   private final List<String> dwcaTerms = List.of(TERM);
 
-
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestEpochOrLowestSeries.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestEpochOrLowestSeries.java
@@ -2,8 +2,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphi
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class EarliestEpochOrLowestSeries extends AbstractChronoStratigraphy {
 
@@ -11,8 +9,8 @@ public class EarliestEpochOrLowestSeries extends AbstractChronoStratigraphy {
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestEraOrLowestErathem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestEraOrLowestErathem.java
@@ -2,8 +2,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphi
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class EarliestEraOrLowestErathem extends AbstractChronoStratigraphy {
 
@@ -11,8 +9,8 @@ public class EarliestEraOrLowestErathem extends AbstractChronoStratigraphy {
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestPeriodOrLowestSystem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestPeriodOrLowestSystem.java
@@ -2,8 +2,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphi
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class EarliestPeriodOrLowestSystem extends AbstractChronoStratigraphy {
 
@@ -11,8 +9,8 @@ public class EarliestPeriodOrLowestSystem extends AbstractChronoStratigraphy {
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestAgeOrHighestStage.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestAgeOrHighestStage.java
@@ -2,8 +2,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphi
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class LatestAgeOrHighestStage extends AbstractChronoStratigraphy {
 
@@ -11,8 +9,8 @@ public class LatestAgeOrHighestStage extends AbstractChronoStratigraphy {
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestEonOrHighestEonothem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestEonOrHighestEonothem.java
@@ -2,8 +2,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphi
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class LatestEonOrHighestEonothem extends AbstractChronoStratigraphy {
 
@@ -11,8 +9,8 @@ public class LatestEonOrHighestEonothem extends AbstractChronoStratigraphy {
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestEpochOrHighestSeries.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestEpochOrHighestSeries.java
@@ -2,8 +2,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphi
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class LatestEpochOrHighestSeries extends AbstractChronoStratigraphy {
 
@@ -11,8 +9,8 @@ public class LatestEpochOrHighestSeries extends AbstractChronoStratigraphy {
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestEraOrHighestErathem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestEraOrHighestErathem.java
@@ -2,8 +2,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphi
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class LatestEraOrHighestErathem extends AbstractChronoStratigraphy {
 
@@ -11,8 +9,8 @@ public class LatestEraOrHighestErathem extends AbstractChronoStratigraphy {
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestPeriodOrHighestSystem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestPeriodOrHighestSystem.java
@@ -2,8 +2,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphi
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class LatestPeriodOrHighestSystem extends AbstractChronoStratigraphy {
 
@@ -11,8 +9,8 @@ public class LatestPeriodOrHighestSystem extends AbstractChronoStratigraphy {
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Bed.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Bed.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.lithostratigraphic
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class Bed extends Term {
 
@@ -16,13 +14,13 @@ public class Bed extends Term {
       "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/lithostratigraphicAttributions/lithostratigraphicAttribution/0/bed");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Formation.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Formation.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.lithostratigraphic
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class Formation extends Term {
 
@@ -16,13 +14,13 @@ public class Formation extends Term {
       "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/lithostratigraphicAttributions/lithostratigraphicAttribution/0/formation");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Group.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Group.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.lithostratigraphic
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class Group extends Term {
 
@@ -16,13 +14,13 @@ public class Group extends Term {
       "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/lithostratigraphicAttributions/lithostratigraphicAttribution/0/group");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Member.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Member.java
@@ -3,8 +3,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy.lithostratigraphic
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 
 public class Member extends Term {
 
@@ -16,13 +14,13 @@ public class Member extends Term {
       "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/lithostratigraphicAttributions/lithostratigraphicAttribution/0/member");
 
   @Override
-  public String retrieveFromDWCA(ArchiveFile archiveFile, Record rec) {
-    return super.searchDWCAForTerm(archiveFile, rec, dwcaTerms);
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchAbcdForTerm(unit, abcdTerms);
+    return super.searchJsonForTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/test/java/eu/dissco/core/translator/component/MappingComponentTest.java
+++ b/src/test/java/eu/dissco/core/translator/component/MappingComponentTest.java
@@ -1,7 +1,6 @@
 package eu.dissco.core.translator.component;
 
 import static eu.dissco.core.translator.TestUtils.DEFAULT_MAPPING;
-import static eu.dissco.core.translator.TestUtils.DWC_DEFAULTS;
 import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static eu.dissco.core.translator.TestUtils.MAPPING_JSON;
 import static eu.dissco.core.translator.TestUtils.SOURCE_SYSTEM_ID;
@@ -11,7 +10,6 @@ import static org.mockito.BDDMockito.given;
 
 import eu.dissco.core.translator.properties.WebClientProperties;
 import eu.dissco.core.translator.repository.MappingRepository;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/eu/dissco/core/translator/repository/DwcaRepositoryTest.java
+++ b/src/test/java/eu/dissco/core/translator/repository/DwcaRepositoryTest.java
@@ -1,0 +1,89 @@
+package eu.dissco.core.translator.repository;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DwcaRepositoryTest extends BaseRepositoryIT {
+
+  private DwcaRepository repository;
+
+  @BeforeEach
+  void setup() {
+    repository = new DwcaRepository(MAPPER, context);
+  }
+
+  @Test
+  void getCoreRecords() {
+    // Given
+    var tableName = "XXX-XXX-XXX_Core";
+    var records = givenCoreRecords();
+    repository.createTable(tableName);
+    repository.postRecords(tableName, records);
+
+    // When
+    var results = repository.getCoreRecords(records.stream().map(Pair::getLeft).toList(),
+        tableName);
+    repository.deleteTable(tableName);
+
+    // Then
+    assertThat(results).isEqualTo(
+        records.stream().collect(Collectors.toMap(Pair::getLeft, Pair::getRight)));
+  }
+
+  @Test
+  void getCoreExtensionRecords() {
+    // Given
+    var tableName = "XXX-XXX-XXX_Extension";
+    var records = givenExtensionRecord();
+    repository.createTable(tableName);
+    repository.postRecords(tableName, records);
+
+    // When
+    var results = repository.getRecords(records.stream().map(Pair::getLeft).toList(), tableName);
+    repository.deleteTable(tableName);
+
+    // Then
+    assertThat(results).isEqualTo(
+        records.stream().collect(groupingBy(Pair::getLeft, mapping(Pair::getRight, toList()))));
+  }
+
+  private ArrayList<Pair<String, JsonNode>> givenExtensionRecord() {
+    var records = new ArrayList<Pair<String, JsonNode>>();
+    for (int i = 0; i < 10; i++) {
+      var id = UUID.randomUUID().toString();
+      for (int j = 0; j < 3; j++) {
+        var pair = Pair.of(
+            id,
+            (JsonNode) MAPPER.createObjectNode()
+        );
+        records.add(pair);
+      }
+    }
+    return records;
+  }
+
+  private List<Pair<String, JsonNode>> givenCoreRecords() {
+    var records = new ArrayList<Pair<String, JsonNode>>();
+    for (int i = 0; i < 10; i++) {
+      var pair = Pair.of(
+          UUID.randomUUID().toString(),
+          (JsonNode) MAPPER.createObjectNode()
+      );
+      records.add(pair);
+    }
+    return records;
+  }
+
+}

--- a/src/test/java/eu/dissco/core/translator/service/DwcaServiceTest.java
+++ b/src/test/java/eu/dissco/core/translator/service/DwcaServiceTest.java
@@ -1,19 +1,19 @@
 package eu.dissco.core.translator.service;
 
-import static eu.dissco.core.translator.TestUtils.DWC_DEFAULTS;
-import static eu.dissco.core.translator.TestUtils.DWC_KEW_DEFAULTS;
 import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
-import eu.dissco.core.translator.component.MappingComponent;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import eu.dissco.core.translator.properties.DwcaProperties;
 import eu.dissco.core.translator.properties.EnrichmentProperties;
 import eu.dissco.core.translator.properties.WebClientProperties;
+import eu.dissco.core.translator.repository.DwcaRepository;
 import eu.dissco.core.translator.repository.SourceSystemRepository;
 import eu.dissco.core.translator.terms.TermMapper;
 import eu.dissco.core.translator.terms.specimen.PhysicalSpecimenIdType;
@@ -22,6 +22,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,6 +63,8 @@ class DwcaServiceTest {
   private EnrichmentProperties enrichmentProperties;
   @Mock
   private SourceSystemRepository repository;
+  @Mock
+  private DwcaRepository dwcaRepository;
 
 
   private DwcaService service;
@@ -72,51 +77,87 @@ class DwcaServiceTest {
   @BeforeEach
   void setup() {
     this.service = new DwcaService(MAPPER, webClientProperties, webClient, dwcaProperties,
-        kafkaService, termMapper, enrichmentProperties, repository);
+        kafkaService, termMapper, enrichmentProperties, repository, dwcaRepository);
 
     // Given
     givenEndpoint();
-    given(termMapper.retrieveFromDWCA(any(), any(), any())).willReturn("someValue");
-    given(termMapper.retrieveFromDWCA(any(PhysicalSpecimenIdType.class), any(), any())).willReturn("cetaf");
+    given(termMapper.retrieveFromDWCA(any(), any())).willReturn("someValue");
+    given(termMapper.retrieveFromDWCA(any(PhysicalSpecimenIdType.class), any())).willReturn(
+        "cetaf");
   }
 
   @Test
   void testRetrieveData() throws IOException {
     // Given
     givenDWCA("/dwca-rbins.zip");
+    given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(9));
 
     // When
     service.retrieveData();
 
     // Then
+    then(dwcaRepository).should(times(2)).createTable(anyString());
+    then(dwcaRepository).should(times(21)).postRecords(anyString(), anyList());
     then(kafkaService).should(times(9)).sendMessage(eq("digital-specimen"), anyString());
     then(kafkaService).should(times(0)).sendMessage(eq("digital-media-object"), anyString());
     cleanup("src/test/resources/dwca/test/dwca-rbins.zip");
+  }
+
+  private Map<String, ObjectNode> givenSpecimenMap(int amount) {
+    var givenMap = new HashMap<String, ObjectNode>();
+    for (int i = 0; i < amount; i++) {
+      var objectNode = MAPPER.createObjectNode();
+      objectNode.put("dwca:ID", "id" + 1);
+      objectNode.put("dwc:basisOfRecord", "PreservedSpecimen");
+      givenMap.put("id:" + i, objectNode);
+    }
+    return givenMap;
   }
 
   @Test
   void testRetrieveDataWithGbifMedia() throws IOException {
     // Given
     givenDWCA("/dwca-kew-gbif-media.zip");
+    given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(19));
+    given(dwcaRepository.getRecords(anyList(), eq("ABC-DDD-ASD_dwc:Identification"))).willReturn(
+        Map.of());
+    given(dwcaRepository.getRecords(anyList(), eq("ABC-DDD-ASD_gbif:Multimedia"))).willReturn(givenImageMap(19));
 
     // When
     service.retrieveData();
 
     // Then
+    then(dwcaRepository).should(times(3)).createTable(anyString());
+    then(dwcaRepository).should(times(19)).postRecords(anyString(), anyList());
     then(kafkaService).should(times(19)).sendMessage(eq("digital-specimen"), anyString());
     then(kafkaService).should(times(19)).sendMessage(eq("digital-media-object"), anyString());
     cleanup("src/test/resources/dwca/test/dwca-kew-gbif-media.zip");
+  }
+
+  private Map<String, List<ObjectNode>> givenImageMap(int amount) {
+    var givenMap = new HashMap<String, List<ObjectNode>>();
+    for (int i = 0; i < amount; i++) {
+      var objectNode = MAPPER.createObjectNode();
+      objectNode.put("dwca:ID", "id" + 1);
+      objectNode.put("dwc:basisOfRecord", "PreservedSpecimen");
+      givenMap.put("id:" + i, List.of(objectNode));
+    }
+    return givenMap;
   }
 
   @Test
   void testRetrieveDataWithAcMedia() throws IOException {
     // Given
     givenDWCA("/dwca-naturalis-ac-media.zip");
+    given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(14));
+    given(dwcaRepository.getRecords(anyList(), eq("ABC-DDD-ASD_http://rs.tdwg.org/ac/terms/Multimedia"))).willReturn(givenImageMap(14));
 
     // When
     service.retrieveData();
 
     // Then
+    then(dwcaRepository).should(times(2)).createTable(anyString());
+    then(dwcaRepository).should(times(2)).postRecords(anyString(), anyList());
     then(kafkaService).should(times(14)).sendMessage(eq("digital-specimen"), anyString());
     then(kafkaService).should(times(14)).sendMessage(eq("digital-media-object"), anyString());
     cleanup("src/test/resources/dwca/test/dwca-naturalis-ac-media.zip");
@@ -126,14 +167,29 @@ class DwcaServiceTest {
   void testRetrieveDataWithAssociatedMedia() throws IOException {
     // Given
     givenDWCA("/dwca-lux-associated-media.zip");
+    given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMapWithMedia(20));
 
     // When
     service.retrieveData();
 
     // Then
+    then(dwcaRepository).should(times(1)).createTable(anyString());
+    then(dwcaRepository).should(times(1)).postRecords(anyString(), anyList());
     then(kafkaService).should(times(20)).sendMessage(eq("digital-specimen"), anyString());
-    then(kafkaService).should(times(21)).sendMessage(eq("digital-media-object"), anyString());
+    then(kafkaService).should(times(40)).sendMessage(eq("digital-media-object"), anyString());
     cleanup("src/test/resources/dwca/test/dwca-lux-associated-media.zip");
+  }
+
+  private Map<String, ObjectNode> givenSpecimenMapWithMedia(int amount) {
+    var givenMap = new HashMap<String, ObjectNode>();
+    for (int i = 0; i < amount; i++) {
+      var objectNode = MAPPER.createObjectNode();
+      objectNode.put("dwca:ID", "id" + 1);
+      objectNode.put("dwc:basisOfRecord", "PreservedSpecimen");
+      objectNode.put("dwc:associatedMedia", "https://test.test | https://test2.test");
+      givenMap.put("id:" + i, objectNode);
+    }
+    return givenMap;
   }
 
   private void givenEndpoint() {
@@ -154,6 +210,7 @@ class DwcaServiceTest {
             new DefaultDataBufferFactory(), 1000));
   }
 
+  //TODO: Add test where id needs combined
 
   private String getAbsolutePath() {
     String path = "src/test/resources/dwca/test";

--- a/src/test/java/eu/dissco/core/translator/service/IngestionUtlityTest.java
+++ b/src/test/java/eu/dissco/core/translator/service/IngestionUtlityTest.java
@@ -1,0 +1,74 @@
+package eu.dissco.core.translator.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import eu.dissco.core.translator.exception.DiSSCoDataException;
+import eu.dissco.core.translator.exception.OrganizationNotRorId;
+import eu.dissco.core.translator.exception.UnknownPhysicalSpecimenIdType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IngestionUtlityTest {
+
+  @Test
+  void testCombined() throws DiSSCoDataException {
+    // Given
+    var type = "combined";
+    var organisationId = "https://ror.org/0566bfb96";
+    var id = "12345";
+
+    // When
+    var result = IngestionUtility.getPhysicalSpecimenId(type, organisationId, id);
+
+    // Then
+    assertThat(result).isEqualTo(id + ":0566bfb96");
+  }
+
+  @Test
+  void testCetaf() throws DiSSCoDataException {
+    // Given
+    var type = "cetaf";
+    var organisationId = "https://ror.org/0566bfb96";
+    var id = "https://globally.unique.com/12345";
+
+    // When
+    var result = IngestionUtility.getPhysicalSpecimenId(type, organisationId, id);
+
+    // Then
+    assertThat(result).isEqualTo(id);
+  }
+
+  @Test
+  void testInvalidIdType() {
+    // Given
+    var type = "unknown";
+    var organisationId = "https://ror.org/0566bfb96";
+    var id = "https://globally.unique.com/12345";
+
+    // When
+    var exception = assertThrowsExactly(UnknownPhysicalSpecimenIdType.class,
+        () -> IngestionUtility.getPhysicalSpecimenId(type, organisationId, id));
+
+    // Then
+    assertThat(exception).isInstanceOf(UnknownPhysicalSpecimenIdType.class);
+  }
+
+  @Test
+  void testInvalidRoR() {
+    // Given
+    var type = "combined";
+    var organisationId = "0566bfb96";
+    var id = "https://globally.unique.com/12345";
+
+    // When
+    var exception = assertThrowsExactly(OrganizationNotRorId.class,
+        () -> IngestionUtility.getPhysicalSpecimenId(type, organisationId, id));
+
+    // Then
+    assertThat(exception).isInstanceOf(OrganizationNotRorId.class);
+  }
+
+}

--- a/src/test/java/eu/dissco/core/translator/service/KafkaServiceTest.java
+++ b/src/test/java/eu/dissco/core/translator/service/KafkaServiceTest.java
@@ -1,26 +1,16 @@
 package eu.dissco.core.translator.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.doAnswer;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import eu.dissco.core.translator.TestUtils;
-import java.sql.BatchUpdateException;
-import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.TopicPartition;
-import org.jooq.exception.DataAccessException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.postgresql.util.PSQLException;
 import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;

--- a/src/test/java/eu/dissco/core/translator/terms/LicenseTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/LicenseTest.java
@@ -1,30 +1,21 @@
 package eu.dissco.core.translator.terms;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import efg.ContentMetadata;
 import efg.DataSets.DataSet;
 import efg.IPRStatements;
 import efg.IPRStatements.Licenses;
 import efg.Statement;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class LicenseTest {
 
   private final License license = new License();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   private static DataSet getDataSet(String licenseString, boolean useUri) {
     var dataset = new DataSet();
@@ -48,12 +39,11 @@ class LicenseTest {
   void testRetrieveFromDWCA() {
     // Given
     var licenseString = "https://creativecommons.org/licenses/by-nc/4.0";
-    var archiveField = new ArchiveField(0, DcTerm.license);
-    given(archiveFile.getField("dcterms:license")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(licenseString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dcterms:license", licenseString);
 
     // When
-    var result = license.retrieveFromDWCA(archiveFile, rec);
+    var result = license.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(licenseString);

--- a/src/test/java/eu/dissco/core/translator/terms/LicenseTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/LicenseTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import efg.ContentMetadata;
 import efg.DataSets.DataSet;
 import efg.IPRStatements;
@@ -39,7 +39,7 @@ class LicenseTest {
   void testRetrieveFromDWCA() {
     // Given
     var licenseString = "https://creativecommons.org/licenses/by-nc/4.0";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dcterms:license", licenseString);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/TermMapperTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/TermMapperTest.java
@@ -13,10 +13,6 @@ import eu.dissco.core.translator.terms.specimen.OrganisationId;
 import eu.dissco.core.translator.terms.specimen.PhysicalSpecimenCollection;
 import eu.dissco.core.translator.terms.specimen.PhysicalSpecimenId;
 import java.util.Map;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,10 +24,6 @@ class TermMapperTest {
 
   @Mock
   private MappingComponent mappingComponent;
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record record;
 
   private TermMapper termMapper;
 
@@ -48,7 +40,7 @@ class TermMapperTest {
         Map.of(OrganisationId.TERM, "https://ror.org/02y22ws83"));
 
     // When
-    var result = termMapper.retrieveFromDWCA(organisationId, archiveFile, record);
+    var result = termMapper.retrieveFromDWCA(organisationId, mock(JsonNode.class));
 
     // Then
     assertThat(result).isEqualTo("https://ror.org/02y22ws83");
@@ -61,12 +53,11 @@ class TermMapperTest {
     var dwcaTerm = "dwc:collectionID";
     given(mappingComponent.getFieldMappings()).willReturn(
         Map.of(PhysicalSpecimenCollection.TERM, dwcaTerm));
-    var archiveField = new ArchiveField(0, DwcTerm.collectionID);
-    given(archiveFile.getField(dwcaTerm)).willReturn(archiveField);
-    given(record.value(archiveField.getTerm())).willReturn("TestCollection");
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:collectionID", "TestCollection");
 
     // When
-    var result = termMapper.retrieveFromDWCA(physicalSpecimenCollection, archiveFile, record);
+    var result = termMapper.retrieveFromDWCA(physicalSpecimenCollection, unit);
 
     // Then
     assertThat(result).isEqualTo("TestCollection");
@@ -77,12 +68,13 @@ class TermMapperTest {
     // Given
     var physicalSpecimenCollection = mock(PhysicalSpecimenCollection.class);
     given(physicalSpecimenCollection.getTerm()).willReturn(PhysicalSpecimenCollection.TERM);
+    var attributes = mock(JsonNode.class);
 
     // When
-    termMapper.retrieveFromDWCA(physicalSpecimenCollection, archiveFile, record);
+    termMapper.retrieveFromDWCA(physicalSpecimenCollection, attributes);
 
     // Then
-    then(physicalSpecimenCollection).should().retrieveFromDWCA(archiveFile, record);
+    then(physicalSpecimenCollection).should().retrieveFromDWCA(attributes);
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/translator/terms/TermMapperTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/TermMapperTest.java
@@ -1,12 +1,12 @@
 package eu.dissco.core.translator.terms;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import efg.DataSets.DataSet;
 import eu.dissco.core.translator.component.MappingComponent;
 import eu.dissco.core.translator.terms.specimen.OrganisationId;
@@ -53,7 +53,7 @@ class TermMapperTest {
     var dwcaTerm = "dwc:collectionID";
     given(mappingComponent.getFieldMappings()).willReturn(
         Map.of(PhysicalSpecimenCollection.TERM, dwcaTerm));
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:collectionID", "TestCollection");
 
     // When
@@ -95,7 +95,7 @@ class TermMapperTest {
   void testRetrieveFromABCDFieldMapping() {
     // Given
     var abcdTerm = "abcd:unitID";
-    var attributes = new ObjectMapper().createObjectNode();
+    var attributes = MAPPER.createObjectNode();
     attributes.put(abcdTerm, "123456");
     given(mappingComponent.getFieldMappings()).willReturn(
         Map.of(PhysicalSpecimenId.TERM, abcdTerm));

--- a/src/test/java/eu/dissco/core/translator/terms/media/AccessUriTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/media/AccessUriTest.java
@@ -1,39 +1,26 @@
 package eu.dissco.core.translator.terms.media;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.AcTerm;
-import org.gbif.dwc.terms.DcElement;
-import org.gbif.dwc.terms.DcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class AccessUriTest {
 
   private final AccessUri accessUri = new AccessUri();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var accessUriString = "https://accessuri.eu/image_1";
-    var archiveField = new ArchiveField(0, AcTerm.accessURI);
-    given(archiveFile.getField("ac:accessURI")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(accessUriString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("ac:accessURI", accessUriString);
 
     // When
-    var result = accessUri.retrieveFromDWCA(archiveFile, rec);
+    var result = accessUri.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(accessUriString);

--- a/src/test/java/eu/dissco/core/translator/terms/media/AccessUriTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/media/AccessUriTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.media;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,7 +16,7 @@ class AccessUriTest {
   void testRetrieveFromDWCA() {
     // Given
     var accessUriString = "https://accessuri.eu/image_1";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("ac:accessURI", accessUriString);
 
     // When
@@ -30,7 +30,7 @@ class AccessUriTest {
   void testRetrieveFromABCD() {
     // Given
     var accessUriString = "https://accessuri.eu/image_1";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("abcd:fileURI", accessUriString);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/media/FormatTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/media/FormatTest.java
@@ -1,38 +1,27 @@
 package eu.dissco.core.translator.terms.media;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DcElement;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class FormatTest {
 
   private final Format format = new Format();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var formatString = "StillImage";
-    var archiveField = new ArchiveField(0, DcElement.format);
-    given(archiveFile.getField("dcterms:format")).willReturn(null);
-    given(archiveFile.getField("dc:format")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(formatString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.putNull("dcterms:format");
+    unit.put("dc:format", formatString);
 
     // When
-    var result = format.retrieveFromDWCA(archiveFile, rec);
+    var result = format.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(formatString);

--- a/src/test/java/eu/dissco/core/translator/terms/media/FormatTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/media/FormatTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.media;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,7 +16,7 @@ class FormatTest {
   void testRetrieveFromDWCA() {
     // Given
     var formatString = "StillImage";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.putNull("dcterms:format");
     unit.put("dc:format", formatString);
 
@@ -31,7 +31,7 @@ class FormatTest {
   void testRetrieveFromABCD() {
     // Given
     var formatString = "SpecimenName";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("abcd:format", formatString);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/media/MediaTypeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/media/MediaTypeTest.java
@@ -1,43 +1,30 @@
 package eu.dissco.core.translator.terms.media;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.stream.Stream;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.AcTerm;
-import org.gbif.dwc.terms.DcElement;
-import org.gbif.dwc.terms.DcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class MediaTypeTest {
 
   private final MediaType mediaType = new MediaType();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @ParameterizedTest
   @MethodSource("provideACTypes")
   void testRetrieveFromDWCA(String acType, String expected) {
     // Given
-    var archiveField = new ArchiveField(0, DcTerm.type);
-    given(archiveFile.getField("dcterms:type")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(acType);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dcterms:type", acType);
 
     // When
-    var result = mediaType.retrieveFromDWCA(archiveFile, rec);
+    var result = mediaType.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(expected);
@@ -57,14 +44,13 @@ class MediaTypeTest {
   @MethodSource("provideFormatTypes")
   void testRetrieveFromDWCANoType(String format, String expected) {
     // Given
-    var formatField = new ArchiveField(0, DcElement.format);
-    given(archiveFile.getField("dcterms:type")).willReturn(null);
-    given(archiveFile.getField("dc:type")).willReturn(null);
-    given(archiveFile.getField("dcterms:format")).willReturn(formatField);
-    given(rec.value(formatField.getTerm())).willReturn(format);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.set("dcterms:type", null);
+    unit.set("dc:type", null);
+    unit.put("dcterms:format", format);
 
     // When
-    var result = mediaType.retrieveFromDWCA(archiveFile, rec);
+    var result = mediaType.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(expected);

--- a/src/test/java/eu/dissco/core/translator/terms/media/MediaTypeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/media/MediaTypeTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.media;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,21 +16,7 @@ class MediaTypeTest {
 
   private final MediaType mediaType = new MediaType();
 
-  @ParameterizedTest
-  @MethodSource("provideACTypes")
-  void testRetrieveFromDWCA(String acType, String expected) {
-    // Given
-    var unit = new ObjectMapper().createObjectNode();
-    unit.put("dcterms:type", acType);
-
-    // When
-    var result = mediaType.retrieveFromDWCA(unit);
-
-    // Then
-    assertThat(result).isEqualTo(expected);
-  }
-
-  private static Stream<Arguments> provideACTypes(){
+  private static Stream<Arguments> provideACTypes() {
     return Stream.of(
         Arguments.of("StillImage", "2DImageObject"),
         Arguments.of("Image", "2DImageObject"),
@@ -40,13 +26,44 @@ class MediaTypeTest {
     );
   }
 
+  private static Stream<Arguments> provideFormatTypes() {
+    return Stream.of(
+        Arguments.of("image/jpeg", "2DImageObject"),
+        Arguments.of("audio/example", "AudioObject"),
+        Arguments.of("video/example", "VideoObject"),
+        Arguments.of("RandomString", null)
+    );
+  }
+
+  private static Stream<Arguments> provideABCDFormats() {
+    return Stream.of(
+        Arguments.of("image/jpeg", "2DImageObject"),
+        Arguments.of("unknown/format", null),
+        Arguments.of(null, null)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideACTypes")
+  void testRetrieveFromDWCA(String acType, String expected) {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("dcterms:type", acType);
+
+    // When
+    var result = mediaType.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(expected);
+  }
+
   @ParameterizedTest
   @MethodSource("provideFormatTypes")
   void testRetrieveFromDWCANoType(String format, String expected) {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
-    unit.set("dcterms:type", null);
-    unit.set("dc:type", null);
+    var unit = MAPPER.createObjectNode();
+    unit.putNull("dcterms:type");
+    unit.putNull("dc:type");
     unit.put("dcterms:format", format);
 
     // When
@@ -56,20 +73,11 @@ class MediaTypeTest {
     assertThat(result).isEqualTo(expected);
   }
 
-  private static Stream<Arguments> provideFormatTypes(){
-    return Stream.of(
-        Arguments.of("image/jpeg", "2DImageObject"),
-        Arguments.of("audio/example", "AudioObject"),
-        Arguments.of("video/example", "VideoObject"),
-        Arguments.of("RandomString", null)
-    );
-  }
-
   @ParameterizedTest
   @MethodSource("provideABCDFormats")
   void testRetrieveFromABCD(String format, String expected) {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     if (format != null) {
       unit.put("abcd:format", format);
     }
@@ -79,14 +87,6 @@ class MediaTypeTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
-  }
-
-  private static Stream<Arguments> provideABCDFormats(){
-    return Stream.of(
-        Arguments.of("image/jpeg", "2DImageObject"),
-        Arguments.of("unknown/format", null),
-        Arguments.of(null, null)
-    );
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/CollectingNumberTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/CollectingNumberTest.java
@@ -1,16 +1,10 @@
 package eu.dissco.core.translator.terms.specimen;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -19,20 +13,15 @@ class CollectingNumberTest {
   private static final String NUMBER = "245";
 
   private final CollectingNumber collectingNumber = new CollectingNumber();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var archiveField = new ArchiveField(0, DwcTerm.scientificName);
-    given(archiveFile.getField("dwc:recordNumber")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(NUMBER);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:recordNumber", NUMBER);
 
     // When
-    var result = collectingNumber.retrieveFromDWCA(archiveFile, rec);
+    var result = collectingNumber.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(NUMBER);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/CollectingNumberTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/CollectingNumberTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,7 +17,7 @@ class CollectingNumberTest {
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:recordNumber", NUMBER);
 
     // When
@@ -30,7 +30,7 @@ class CollectingNumberTest {
   @Test
   void testRetrieveFromABCD() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("abcd:collectorsFieldNumber", NUMBER);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/CollectorTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/CollectorTest.java
@@ -1,16 +1,10 @@
 package eu.dissco.core.translator.terms.specimen;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -18,20 +12,15 @@ class CollectorTest {
 
   private static final String COLLECTOR_NAME = "Fricke, Ronald";
   private final Collector collector = new Collector();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var archiveField = new ArchiveField(0, DwcTerm.preparations);
-    given(archiveFile.getField("dwc:recordedBy")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(COLLECTOR_NAME);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:recordedBy", COLLECTOR_NAME);
 
     // When
-    var result = collector.retrieveFromDWCA(archiveFile, rec);
+    var result = collector.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(COLLECTOR_NAME);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/CollectorTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/CollectorTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,7 +16,7 @@ class CollectorTest {
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:recordedBy", COLLECTOR_NAME);
 
     // When
@@ -30,7 +30,7 @@ class CollectorTest {
   void testRetrieveFromABCDMultipleAgents() {
     // Given
     var collectorName2 = "Troschel, Hans-Julius";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("abcd:gathering/agents/gatheringAgent/0/person/fullName", COLLECTOR_NAME);
     unit.put("abcd:gathering/agents/gatheringAgent/0/person/agentText", "Tom");
     unit.put("abcd:gathering/agents/gatheringAgent/1/person/agentText", collectorName2);
@@ -46,7 +46,7 @@ class CollectorTest {
   @Test
   void testRetrieveFromABCDGatheringAgentsText() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("abcd:gathering/agents/gatheringAgentsText", COLLECTOR_NAME);
 
     // When
@@ -59,7 +59,7 @@ class CollectorTest {
   @Test
   void testRetrieveFromABCDEmpty() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
 
     // When
     var result = collector.retrieveFromABCD(unit);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/DataSetIdTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/DataSetIdTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,7 +16,7 @@ class DataSetIdTest {
   void testRetrieveFromDWCA() {
     // Given
     var datasetIdString = "datasetId-123456";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:datasetID", datasetIdString);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/DataSetIdTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/DataSetIdTest.java
@@ -1,39 +1,26 @@
 package eu.dissco.core.translator.terms.specimen;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
-import eu.dissco.core.translator.terms.License;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DcTerm;
-import org.gbif.dwc.terms.DwcTerm;
-import org.gbif.dwc.terms.DwcaTerm;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DataSetIdTest {
 
   private final DatasetId datasetId = new DatasetId();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var datasetIdString = "datasetId-123456";
-    var archiveField = new ArchiveField(0, DwcTerm.datasetID);
-    given(archiveFile.getField("dwc:datasetID")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(datasetIdString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:datasetID", datasetIdString);
 
     // When
-    var result = datasetId.retrieveFromDWCA(archiveFile, rec);
+    var result = datasetId.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(datasetIdString);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/DateCollectedTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/DateCollectedTest.java
@@ -1,16 +1,10 @@
 package eu.dissco.core.translator.terms.specimen;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -19,20 +13,15 @@ class DateCollectedTest {
   private static final String DATE = "1924-11-20";
 
   private final DateCollected dateCollected = new DateCollected();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var archiveField = new ArchiveField(0, DwcTerm.scientificName);
-    given(archiveFile.getField("dwc:eventDate")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(DATE);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:eventDate", DATE);
 
     // When
-    var result = dateCollected.retrieveFromDWCA(archiveFile, rec);
+    var result = dateCollected.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(DATE);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/DateCollectedTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/DateCollectedTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,7 +17,7 @@ class DateCollectedTest {
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:eventDate", DATE);
 
     // When
@@ -30,7 +30,7 @@ class DateCollectedTest {
   @Test
   void testRetrieveFromABCD() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("abcd:gathering/dateTime/isodateTimeStart", DATE);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/HasMediaTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/HasMediaTest.java
@@ -1,10 +1,12 @@
 package eu.dissco.core.translator.terms.specimen;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -17,8 +19,27 @@ class HasMediaTest {
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:associatedMedia", MEDIA_URL);
+
+    // When
+    var result = hasMedia.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo("true");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"gbif:Multimedia", "http://rs.tdwg.org/ac/terms/Multimedia"})
+  void testRetrieveFromDWCAExtension(String extensionName) {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    var array = MAPPER.createArrayNode();
+    var image = MAPPER.createObjectNode();
+    array.add(image);
+    var extensions = MAPPER.createObjectNode();
+    extensions.put(extensionName, array);
+    unit.put("extensions", extensions);
 
     // When
     var result = hasMedia.retrieveFromDWCA(unit);
@@ -30,7 +51,7 @@ class HasMediaTest {
   @Test
   void testRetrieveFromABCD() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("abcd:multiMediaObjects/multiMediaObject/0/fileURI", MEDIA_URL);
 
     // When
@@ -43,7 +64,7 @@ class HasMediaTest {
   @Test
   void testRetrieveFromABCDNoMedia() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("", MEDIA_URL);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/HasMediaTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/HasMediaTest.java
@@ -1,16 +1,10 @@
 package eu.dissco.core.translator.terms.specimen;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -19,20 +13,15 @@ class HasMediaTest {
   private static final String MEDIA_URL = "https://archimg.mnhn.lu/Collections/Collections/ZS536.JPG";
 
   private final HasMedia hasMedia = new HasMedia();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var archiveField = new ArchiveField(0, DwcTerm.associatedMedia);
-    given(archiveFile.getField("dwc:associatedMedia")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(MEDIA_URL);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:associatedMedia", MEDIA_URL);
 
     // When
-    var result = hasMedia.retrieveFromDWCA(archiveFile, rec);
+    var result = hasMedia.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo("true");

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/ModifiedTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/ModifiedTest.java
@@ -1,29 +1,22 @@
 package eu.dissco.core.translator.terms.specimen;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ModifiedTest {
 
   private final Modified modified = new Modified();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var licenseString = "23-03-1989";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dcterms:modified", licenseString);
 
     // When
@@ -37,7 +30,7 @@ class ModifiedTest {
   void testRetrieveFromABCD() {
     // Given
     String modifiedString = "1674553668909";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("abcd:dateLastEdited", modifiedString);
 
     // When
@@ -50,7 +43,7 @@ class ModifiedTest {
   @Test
   void testRetrieveFromABCDEmpty() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
 
     // When
     var result = modified.retrieveFromABCD(unit);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/ModifiedTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/ModifiedTest.java
@@ -1,13 +1,10 @@
 package eu.dissco.core.translator.terms.specimen;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveField;
 import org.gbif.dwc.ArchiveFile;
 import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -26,12 +23,11 @@ class ModifiedTest {
   void testRetrieveFromDWCA() {
     // Given
     var licenseString = "23-03-1989";
-    var archiveField = new ArchiveField(0, DcTerm.modified);
-    given(archiveFile.getField("dcterms:modified")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(licenseString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dcterms:modified", licenseString);
 
     // When
-    var result = modified.retrieveFromDWCA(archiveFile, rec);
+    var result = modified.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(licenseString);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/ObjectTypeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/ObjectTypeTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,7 +16,7 @@ class ObjectTypeTest {
   void testRetrieveFromDWCA() {
     // Given
     var objectTypeString = "alcohol jar";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:preparations", objectTypeString);
 
     // When
@@ -30,7 +30,7 @@ class ObjectTypeTest {
   void testRetrieveFromABCD() {
     // Given
     var objectTypeString = "alcohol jar";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("abcd:kindOfUnit/0/value", objectTypeString);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/ObjectTypeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/ObjectTypeTest.java
@@ -1,39 +1,26 @@
 package eu.dissco.core.translator.terms.specimen;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.Instant;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DcTerm;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ObjectTypeTest {
 
   private final ObjectType objectType = new ObjectType();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var objectTypeString = "alcohol jar";
-    var archiveField = new ArchiveField(0, DwcTerm.preparations);
-    given(archiveFile.getField("dwc:preparations")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(objectTypeString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:preparations", objectTypeString);
 
     // When
-    var result = objectType.retrieveFromDWCA(archiveFile, rec);
+    var result = objectType.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(objectTypeString);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenCollectionTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenCollectionTest.java
@@ -1,36 +1,27 @@
 package eu.dissco.core.translator.terms.specimen;
 
-import static org.mockito.BDDMockito.given;
 import static org.assertj.core.api.Assertions.assertThat;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class PhysicalSpecimenCollectionTest {
 
   private final PhysicalSpecimenCollection physicalSpecimenCollection = new PhysicalSpecimenCollection();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var collectionString = "collection-123456";
-    var archiveField = new ArchiveField(0, DwcTerm.collectionCode);
-    given(archiveFile.getField("dwc:collectionID")).willReturn(null);
-    given(archiveFile.getField("dwc:collectionCode")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(collectionString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.putNull("dwc:collectionID");
+    unit.put("dwc:collectionCode", collectionString);
 
     // When
-    var result = physicalSpecimenCollection.retrieveFromDWCA(archiveFile, rec);
+    var result = physicalSpecimenCollection.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(collectionString);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenCollectionTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenCollectionTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,7 +16,7 @@ class PhysicalSpecimenCollectionTest {
   void testRetrieveFromDWCA() {
     // Given
     var collectionString = "collection-123456";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.putNull("dwc:collectionID");
     unit.put("dwc:collectionCode", collectionString);
 

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenIdTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenIdTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,7 +16,7 @@ class PhysicalSpecimenIdTest {
   void testRetrieveFromDWCA() {
     // Given
     var id = "123456789";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:occurrenceID", id);
 
     // When
@@ -30,7 +30,7 @@ class PhysicalSpecimenIdTest {
   void testRetrieveFromABCD() {
     // Given
     var id = "123456789";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("abcd:unitID", id);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenIdTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenIdTest.java
@@ -1,37 +1,26 @@
 package eu.dissco.core.translator.terms.specimen;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class PhysicalSpecimenIdTest {
 
   private final PhysicalSpecimenId physicalSpecimenId = new PhysicalSpecimenId();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var id = "123456789";
-    var archiveField = new ArchiveField(0, DwcTerm.occurrenceID);
-    given(archiveFile.getField("dwc:occurrenceID")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(id);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:occurrenceID", id);
 
     // When
-    var result = physicalSpecimenId.retrieveFromDWCA(archiveFile, rec);
+    var result = physicalSpecimenId.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(id);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/SpecimenNameTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/SpecimenNameTest.java
@@ -1,29 +1,22 @@
 package eu.dissco.core.translator.terms.specimen;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class SpecimenNameTest {
 
   private final SpecimenName specimenName = new SpecimenName();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var specimenNameString = "SpecimenName";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:scientificName", specimenNameString);
 
     // When
@@ -37,7 +30,7 @@ class SpecimenNameTest {
   void testRetrieveFromABCDEFG() {
     // Given
     var specimenNameString = "SpecimenName";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put(
         "abcd-efg:identifications/identification/0/result/mineralRockIdentified/classifiedName/fullScientificNameString",
         specimenNameString);
@@ -52,18 +45,21 @@ class SpecimenNameTest {
   @Test
   void testRetrieveFromABCDWithPreferred() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put(
         "abcd:identifications/identification/0/preferredFlag", false);
-    unit.put("abcd:identifications/identification/0/result/taxonIdentified/scientificName/fullScientificNameString",
+    unit.put(
+        "abcd:identifications/identification/0/result/taxonIdentified/scientificName/fullScientificNameString",
         "Arrabidaea chica (Humb. & Bonpl.) B.Verl.");
     unit.put(
         "abcd:identifications/identification/1/preferredFlag", true);
-    unit.put("abcd:identifications/identification/1/result/taxonIdentified/scientificName/fullScientificNameString",
+    unit.put(
+        "abcd:identifications/identification/1/result/taxonIdentified/scientificName/fullScientificNameString",
         "Bignonia chica Humb. & Bonpl.");
     unit.put(
         "abcd:identifications/identification/2/preferredFlag", false);
-    unit.put("abcd:identifications/identification/2/result/taxonIdentified/scientificName/fullScientificNameString",
+    unit.put(
+        "abcd:identifications/identification/2/result/taxonIdentified/scientificName/fullScientificNameString",
         "Arrabidaea chica var. thyrsoidea Bureau");
 
     // When
@@ -77,7 +73,7 @@ class SpecimenNameTest {
   void testRetrieveFromABCD() {
     // Given
     var specimenNameString = "SpecimenName";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put(
         "abcd:identifications/identification/0/result/taxonIdentified/scientificName/fullScientificNameString",
         specimenNameString);
@@ -92,7 +88,7 @@ class SpecimenNameTest {
   @Test
   void testRetrieveFromABCDNotPresent() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
 
     // When
     var result = specimenName.retrieveFromABCD(unit);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/SpecimenNameTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/SpecimenNameTest.java
@@ -1,14 +1,10 @@
 package eu.dissco.core.translator.terms.specimen;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import eu.dissco.core.translator.terms.specimen.SpecimenName;
-import org.gbif.dwc.ArchiveField;
 import org.gbif.dwc.ArchiveFile;
 import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -27,12 +23,11 @@ class SpecimenNameTest {
   void testRetrieveFromDWCA() {
     // Given
     var specimenNameString = "SpecimenName";
-    var archiveField = new ArchiveField(0, DwcTerm.scientificName);
-    given(archiveFile.getField("dwc:scientificName")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(specimenNameString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:scientificName", specimenNameString);
 
     // When
-    var result = specimenName.retrieveFromDWCA(archiveFile, rec);
+    var result = specimenName.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(specimenNameString);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/TypeStatusTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/TypeStatusTest.java
@@ -1,16 +1,10 @@
 package eu.dissco.core.translator.terms.specimen;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -19,20 +13,15 @@ class TypeStatusTest {
   private static final String STATUS = "holotype | FULL_NAME | CITATION";
 
   private final TypeStatus typeStatus = new TypeStatus();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var archiveField = new ArchiveField(0, DwcTerm.scientificName);
-    given(archiveFile.getField("dwc:typeStatus")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(STATUS);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:typeStatus", STATUS);
 
     // When
-    var result = typeStatus.retrieveFromDWCA(archiveFile, rec);
+    var result = typeStatus.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(STATUS);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/TypeStatusTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/TypeStatusTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,8 +17,27 @@ class TypeStatusTest {
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:typeStatus", STATUS);
+
+    // When
+    var result = typeStatus.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(STATUS);
+  }
+
+  @Test
+  void testRetrieveFromDWCAInExtension() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    var array = MAPPER.createArrayNode();
+    var extension = MAPPER.createObjectNode();
+    extension.put("dwc:typeStatus", STATUS);
+    array.add(extension);
+    var extensions = MAPPER.createObjectNode();
+    extensions.set("dwc:Identification", array);
+    unit.set("extensions", extensions);
 
     // When
     var result = typeStatus.retrieveFromDWCA(unit);
@@ -30,7 +49,7 @@ class TypeStatusTest {
   @Test
   void testRetrieveFromABCD() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put(
         "abcd:specimenUnit/nomenclaturalTypeDesignations/nomenclaturalTypeDesignation/0/typeStatus",
         "holotype");
@@ -54,7 +73,7 @@ class TypeStatusTest {
   @Test
   void testRetrieveFromABCDNoTypeStatus() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
 
     // When
     var result = typeStatus.retrieveFromABCD(unit);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/ContinentTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/ContinentTest.java
@@ -1,37 +1,26 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
-import eu.dissco.core.translator.terms.specimen.DatasetId;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ContinentTest {
 
   private final Continent continent = new Continent();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var continentString = "Europe";
-    var archiveField = new ArchiveField(0, DwcTerm.continent);
-    given(archiveFile.getField("dwc:continent")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(continentString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:continent", continentString);
 
     // When
-    var result = continent.retrieveFromDWCA(archiveFile, rec);
+    var result = continent.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(continentString);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/ContinentTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/ContinentTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,7 +16,7 @@ class ContinentTest {
   void testRetrieveFromDWCA() {
     // Given
     var continentString = "Europe";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:continent", continentString);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/CountryCodeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/CountryCodeTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,7 +17,7 @@ class CountryCodeTest {
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:countryCode", COUNTRY_CODE);
 
     // When
@@ -30,7 +30,7 @@ class CountryCodeTest {
   @Test
   void testRetrieveFromABCD() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("abcd:gathering/country/iso3166Code", COUNTRY_CODE);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/CountryCodeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/CountryCodeTest.java
@@ -1,17 +1,10 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import eu.dissco.core.translator.terms.specimen.ObjectType;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -20,20 +13,15 @@ class CountryCodeTest {
   private static final String COUNTRY_CODE = "DEU";
 
   private final CountryCode countryCode = new CountryCode();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var archiveField = new ArchiveField(0, DwcTerm.countryCode);
-    given(archiveFile.getField("dwc:countryCode")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(COUNTRY_CODE);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:countryCode", COUNTRY_CODE);
 
     // When
-    var result = countryCode.retrieveFromDWCA(archiveFile, rec);
+    var result = countryCode.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(COUNTRY_CODE);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/CountryTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/CountryTest.java
@@ -1,37 +1,27 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class CountryTest {
+
   private static final String COUNTRY = "Germany";
 
   private final Country country = new Country();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var archiveField = new ArchiveField(0, DwcTerm.country);
-    given(archiveFile.getField("dwc:country")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(COUNTRY);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:country", COUNTRY);
 
     // When
-    var result = country.retrieveFromDWCA(archiveFile, rec);
+    var result = country.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(COUNTRY);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/CountryTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/CountryTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,7 +17,7 @@ class CountryTest {
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:country", COUNTRY);
 
     // When
@@ -30,7 +30,7 @@ class CountryTest {
   @Test
   void testRetrieveFromABCD() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("abcd:gathering/country/name/value", COUNTRY);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/CountyTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/CountyTest.java
@@ -1,36 +1,26 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class CountyTest {
 
   private final County county = new County();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var countyString = "Northumberland";
-    var archiveField = new ArchiveField(0, DwcTerm.county);
-    given(archiveFile.getField("dwc:county")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(countyString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:county", countyString);
 
     // When
-    var result = county.retrieveFromDWCA(archiveFile, rec);
+    var result = county.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(countyString);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/CountyTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/CountyTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,7 +16,7 @@ class CountyTest {
   void testRetrieveFromDWCA() {
     // Given
     var countyString = "Northumberland";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:county", countyString);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/DecimalLatitudeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/DecimalLatitudeTest.java
@@ -1,37 +1,27 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DecimalLatitudeTest {
+
   private static final String LATITUDE_STRING = "53.33167";
 
   private final DecimalLatitude decimalLatitude = new DecimalLatitude();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var archiveField = new ArchiveField(0, DwcTerm.decimalLatitude);
-    given(archiveFile.getField("dwc:decimalLatitude")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(LATITUDE_STRING);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:decimalLatitude", LATITUDE_STRING);
 
     // When
-    var result = decimalLatitude.retrieveFromDWCA(archiveFile, rec);
+    var result = decimalLatitude.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(LATITUDE_STRING);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/DecimalLatitudeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/DecimalLatitudeTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,7 +17,7 @@ class DecimalLatitudeTest {
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:decimalLatitude", LATITUDE_STRING);
 
     // When
@@ -30,7 +30,7 @@ class DecimalLatitudeTest {
   @Test
   void testRetrieveFromABCD() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put(
         "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/latitudeDecimal",
         LATITUDE_STRING);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/DecimalLongitudeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/DecimalLongitudeTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,7 +17,7 @@ class DecimalLongitudeTest {
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:decimalLongitude", LONGITUDE_STRING);
 
     // When
@@ -30,7 +30,7 @@ class DecimalLongitudeTest {
   @Test
   void testRetrieveFromABCD() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put(
         "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/longitudeDecimal",
         LONGITUDE_STRING);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/DecimalLongitudeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/DecimalLongitudeTest.java
@@ -1,37 +1,27 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DecimalLongitudeTest {
+
   private static final String LONGITUDE_STRING = "10.48778";
 
   private final DecimalLongitude decimalLongitude = new DecimalLongitude();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var archiveField = new ArchiveField(0, DwcTerm.decimalLongitude);
-    given(archiveFile.getField("dwc:decimalLongitude")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(LONGITUDE_STRING);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:decimalLongitude", LONGITUDE_STRING);
 
     // When
-    var result = decimalLongitude.retrieveFromDWCA(archiveFile, rec);
+    var result = decimalLongitude.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(LONGITUDE_STRING);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/GeodeticDatumTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/GeodeticDatumTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,7 +17,7 @@ class GeodeticDatumTest {
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:geodeticDatum", GEODETIC_DATUM_STRING);
 
     // When
@@ -30,7 +30,7 @@ class GeodeticDatumTest {
   @Test
   void testRetrieveFromABCD() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put(
         "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/spatialDatum",
         GEODETIC_DATUM_STRING);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/GeodeticDatumTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/GeodeticDatumTest.java
@@ -1,16 +1,10 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -19,20 +13,15 @@ class GeodeticDatumTest {
   private static final String GEODETIC_DATUM_STRING = "WGS84";
 
   private final GeodeticDatum geodeticDatum = new GeodeticDatum();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var archiveField = new ArchiveField(0, DwcTerm.geodeticDatum);
-    given(archiveFile.getField("dwc:geodeticDatum")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(GEODETIC_DATUM_STRING);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:geodeticDatum", GEODETIC_DATUM_STRING);
 
     // When
-    var result = geodeticDatum.retrieveFromDWCA(archiveFile, rec);
+    var result = geodeticDatum.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(GEODETIC_DATUM_STRING);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/IslandGroupTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/IslandGroupTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,7 +16,7 @@ class IslandGroupTest {
   void testRetrieveFromDWCA() {
     // Given
     var islandGroupString = "Harrison Islands";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:islandGroup", islandGroupString);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/IslandGroupTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/IslandGroupTest.java
@@ -1,36 +1,26 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class IslandGroupTest {
 
   private final IslandGroup islandGroup = new IslandGroup();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var islandGroupString = "Harrison Islands";
-    var archiveField = new ArchiveField(0, DwcTerm.islandGroup);
-    given(archiveFile.getField("dwc:islandGroup")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(islandGroupString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:islandGroup", islandGroupString);
 
     // When
-    var result = islandGroup.retrieveFromDWCA(archiveFile, rec);
+    var result = islandGroup.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(islandGroupString);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/IslandTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/IslandTest.java
@@ -1,36 +1,26 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class IslandTest {
 
   private final Island island = new Island();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var islandString = "Texel";
-    var archiveField = new ArchiveField(0, DwcTerm.island);
-    given(archiveFile.getField("dwc:island")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(islandString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:island", islandString);
 
     // When
-    var result = island.retrieveFromDWCA(archiveFile, rec);
+    var result = island.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(islandString);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/IslandTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/IslandTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,7 +16,7 @@ class IslandTest {
   void testRetrieveFromDWCA() {
     // Given
     var islandString = "Texel";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:island", islandString);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/LocalityTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/LocalityTest.java
@@ -1,16 +1,10 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -21,20 +15,15 @@ class LocalityTest {
           + "Niedersachsen/Lower Saxony";
 
   private final Locality locality = new Locality();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var archiveField = new ArchiveField(0, DwcTerm.locality);
-    given(archiveFile.getField("dwc:locality")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(LOCALITY_STRING);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:locality", LOCALITY_STRING);
 
     // When
-    var result = locality.retrieveFromDWCA(archiveFile, rec);
+    var result = locality.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(LOCALITY_STRING);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/LocalityTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/LocalityTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,7 +19,7 @@ class LocalityTest {
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:locality", LOCALITY_STRING);
 
     // When
@@ -32,7 +32,7 @@ class LocalityTest {
   @Test
   void testRetrieveFromABCD() {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("abcd:gathering/localityText/value", LOCALITY_STRING);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/MunicipalityTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/MunicipalityTest.java
@@ -1,36 +1,26 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class MunicipalityTest {
 
   private final Municipality municipality = new Municipality();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var municipalityString = "Gouda";
-    var archiveField = new ArchiveField(0, DwcTerm.municipality);
-    given(archiveFile.getField("dwc:municipality")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(municipalityString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:municipality", municipalityString);
 
     // When
-    var result = municipality.retrieveFromDWCA(archiveFile, rec);
+    var result = municipality.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(municipalityString);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/MunicipalityTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/MunicipalityTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,7 +16,7 @@ class MunicipalityTest {
   void testRetrieveFromDWCA() {
     // Given
     var municipalityString = "Gouda";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:municipality", municipalityString);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/StateProvinceTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/StateProvinceTest.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,7 +16,7 @@ class StateProvinceTest {
   void testRetrieveFromDWCA() {
     // Given
     var stateProvinceString = "Brittany";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:stateProvince", stateProvinceString);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/StateProvinceTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/StateProvinceTest.java
@@ -1,36 +1,26 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class StateProvinceTest {
 
   private final StateProvince stateProvince = new StateProvince();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var stateProvinceString = "Brittany";
-    var archiveField = new ArchiveField(0, DwcTerm.stateProvince);
-    given(archiveFile.getField("dwc:stateProvince")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(stateProvinceString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:stateProvince", stateProvinceString);
 
     // When
-    var result = stateProvince.retrieveFromDWCA(archiveFile, rec);
+    var result = stateProvince.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(stateProvinceString);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/WaterBodyTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/WaterBodyTest.java
@@ -1,12 +1,10 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
-import org.gbif.dwc.ArchiveField;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.gbif.dwc.ArchiveFile;
 import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -25,12 +23,11 @@ class WaterBodyTest {
   void testRetrieveFromDWCA() {
     // Given
     var waterBodyString = "The Aegean Sea";
-    var archiveField = new ArchiveField(0, DwcTerm.waterBody);
-    given(archiveFile.getField("dwc:waterBody")).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(waterBodyString);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put("dwc:waterBody", waterBodyString);
 
     // When
-    var result = waterBody.retrieveFromDWCA(archiveFile, rec);
+    var result = waterBody.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(waterBodyString);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/WaterBodyTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/WaterBodyTest.java
@@ -1,29 +1,22 @@
 package eu.dissco.core.translator.terms.specimen.location;
 
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class WaterBodyTest {
 
   private final WaterBody waterBody = new WaterBody();
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var waterBodyString = "The Aegean Sea";
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put("dwc:waterBody", waterBodyString);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/stratigraphy/BiostratigraphicZoneTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/stratigraphy/BiostratigraphicZoneTest.java
@@ -3,7 +3,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy;
 import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.translator.terms.Term;
 import eu.dissco.core.translator.terms.specimen.stratigraphy.biostratigraphic.HighestBiostratigraphicZone;
 import eu.dissco.core.translator.terms.specimen.stratigraphy.biostratigraphic.LowestBiostratigraphicZone;
@@ -82,7 +81,7 @@ class BiostratigraphicZoneTest {
   @MethodSource("dwcArguments")
   void testRetrieveFromDWCA(Term term, String expected, String dwc) {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put(dwc, expected);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/stratigraphy/BiostratigraphicZoneTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/stratigraphy/BiostratigraphicZoneTest.java
@@ -2,39 +2,29 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy;
 
 import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.translator.terms.Term;
 import eu.dissco.core.translator.terms.specimen.stratigraphy.biostratigraphic.HighestBiostratigraphicZone;
 import eu.dissco.core.translator.terms.specimen.stratigraphy.biostratigraphic.LowestBiostratigraphicZone;
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class BiostratigraphicZoneTest {
 
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
-
   private static Stream<Arguments> dwcArguments() {
     return Stream.of(
         Arguments.of(new HighestBiostratigraphicZone(), "Blancan",
-            "dwc:highestBiostratigraphicZone", DwcTerm.highestBiostratigraphicZone),
+            "dwc:highestBiostratigraphicZone"),
         Arguments.of(new LowestBiostratigraphicZone(), "Maastrichtian",
-            "dwc:lowestBiostratigraphicZone", DwcTerm.lowestBiostratigraphicZone)
+            "dwc:lowestBiostratigraphicZone")
     );
   }
 
@@ -90,15 +80,13 @@ class BiostratigraphicZoneTest {
 
   @ParameterizedTest
   @MethodSource("dwcArguments")
-  void testRetrieveFromDWCA(Term term, String expected, String dwc,
-      org.gbif.dwc.terms.Term dwcTerm) {
+  void testRetrieveFromDWCA(Term term, String expected, String dwc) {
     // Given
-    var archiveField = new ArchiveField(0, dwcTerm);
-    given(archiveFile.getField(dwc)).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(expected);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put(dwc, expected);
 
     // When
-    var result = term.retrieveFromDWCA(archiveFile, rec);
+    var result = term.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(expected);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/stratigraphy/ChronostratigraphicTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/stratigraphy/ChronostratigraphicTest.java
@@ -2,8 +2,8 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy;
 
 import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.translator.terms.Term;
 import eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphic.EarliestAgeOrLowestStage;
 import eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphic.EarliestEonOrLowestEonothem;
@@ -18,15 +18,10 @@ import eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphic
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,33 +31,29 @@ class ChronostratigraphicTest {
   private static final String ABCD_NAME_0 = "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/chronostratigraphicAttributions/chronostratigraphicAttribution/0/chronostratigraphicName";
   private static final String ABCD_DIVISION_1 = "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/chronostratigraphicAttributions/chronostratigraphicAttribution/1/chronoStratigraphicDivision";
   private static final String ABCD_NAME_1 = "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/chronostratigraphicAttributions/chronostratigraphicAttribution/1/chronostratigraphicName";
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
 
   private static Stream<Arguments> dwcArguments() {
     return Stream.of(
         Arguments.of(new EarliestEpochOrLowestSeries(), "Öland Series",
-            "dwc:earliestEpochOrLowestSeries", DwcTerm.earliestEpochOrLowestSeries),
+            "dwc:earliestEpochOrLowestSeries"),
         Arguments.of(new LatestEpochOrHighestSeries(), "Öland Series",
-            "dwc:latestEpochOrHighestSeries", DwcTerm.latestEpochOrHighestSeries),
+            "dwc:latestEpochOrHighestSeries"),
         Arguments.of(new EarliestAgeOrLowestStage(), "Pakerort Stage",
-            "dwc:earliestAgeOrLowestStage", DwcTerm.earliestAgeOrLowestStage),
+            "dwc:earliestAgeOrLowestStage"),
         Arguments.of(new LatestAgeOrHighestStage(), "Pakerort Stage",
-            "dwc:latestAgeOrHighestStage", DwcTerm.latestAgeOrHighestStage),
+            "dwc:latestAgeOrHighestStage"),
         Arguments.of(new EarliestPeriodOrLowestSystem(), "Baltic Ordovician",
-            "dwc:earliestPeriodOrLowestSystem", DwcTerm.earliestPeriodOrLowestSystem),
+            "dwc:earliestPeriodOrLowestSystem"),
         Arguments.of(new LatestPeriodOrHighestSystem(), "Baltic Ordovician",
-            "dwc:latestPeriodOrHighestSystem", DwcTerm.latestPeriodOrHighestSystem),
+            "dwc:latestPeriodOrHighestSystem"),
         Arguments.of(new EarliestEraOrLowestErathem(), "Mesozoic",
-            "dwc:earliestEraOrLowestErathem", DwcTerm.earliestEraOrLowestErathem),
+            "dwc:earliestEraOrLowestErathem"),
         Arguments.of(new LatestEraOrHighestErathem(), "Mesozoic",
-            "dwc:latestEraOrHighestErathem", DwcTerm.latestEraOrHighestErathem),
+            "dwc:latestEraOrHighestErathem"),
         Arguments.of(new EarliestEonOrLowestEonothem(), "Phanerozoic",
-            "dwc:earliestEonOrLowestEonothem", DwcTerm.earliestEonOrLowestEonothem),
+            "dwc:earliestEonOrLowestEonothem"),
         Arguments.of(new LatestEonOrHighestEonothem(), "Phanerozoic",
-            "dwc:latestEonOrHighestEonothem", DwcTerm.latestEonOrHighestEonothem)
+            "dwc:latestEonOrHighestEonothem")
     );
   }
 
@@ -70,7 +61,7 @@ class ChronostratigraphicTest {
     return Stream.of(
         Arguments.of(new EarliestAgeOrLowestStage(), "Pakerort SubStage",
             List.of(Pair.of(ABCD_DIVISION_0, "Stage"), Pair.of(ABCD_NAME_0, "Pakerort Stage"),
-            Pair.of(ABCD_DIVISION_1, "SubStage"), Pair.of(ABCD_NAME_1, "Pakerort SubStage"))),
+                Pair.of(ABCD_DIVISION_1, "SubStage"), Pair.of(ABCD_NAME_1, "Pakerort SubStage"))),
         Arguments.of(new LatestAgeOrHighestStage(), "Pakerort Stage",
             List.of(Pair.of(ABCD_DIVISION_0, "Stage"), Pair.of(ABCD_NAME_0, "Pakerort Stage"))),
         Arguments.of(new EarliestEpochOrLowestSeries(), "Öland Series",
@@ -111,15 +102,13 @@ class ChronostratigraphicTest {
 
   @ParameterizedTest
   @MethodSource("dwcArguments")
-  void testRetrieveFromDWCA(Term term, String expected, String dwc,
-      org.gbif.dwc.terms.Term dwcTerm) {
+  void testRetrieveFromDWCA(Term term, String expected, String dwc) {
     // Given
-    var archiveField = new ArchiveField(0, dwcTerm);
-    given(archiveFile.getField(dwc)).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(expected);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put(dwc, expected);
 
     // When
-    var result = term.retrieveFromDWCA(archiveFile, rec);
+    var result = term.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(expected);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/stratigraphy/ChronostratigraphicTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/stratigraphy/ChronostratigraphicTest.java
@@ -3,7 +3,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy;
 import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.translator.terms.Term;
 import eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphic.EarliestAgeOrLowestStage;
 import eu.dissco.core.translator.terms.specimen.stratigraphy.chronostratigraphic.EarliestEonOrLowestEonothem;
@@ -104,7 +103,7 @@ class ChronostratigraphicTest {
   @MethodSource("dwcArguments")
   void testRetrieveFromDWCA(Term term, String expected, String dwc) {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put(dwc, expected);
 
     // When

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/stratigraphy/LithostratigraphicTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/stratigraphy/LithostratigraphicTest.java
@@ -2,8 +2,8 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy;
 
 import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.translator.terms.Term;
 import eu.dissco.core.translator.terms.specimen.stratigraphy.lithostratigraphic.Bed;
 import eu.dissco.core.translator.terms.specimen.stratigraphy.lithostratigraphic.Formation;
@@ -12,31 +12,21 @@ import eu.dissco.core.translator.terms.specimen.stratigraphy.lithostratigraphic.
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
-import org.gbif.dwc.ArchiveField;
-import org.gbif.dwc.ArchiveFile;
-import org.gbif.dwc.record.Record;
-import org.gbif.dwc.terms.DwcTerm;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class LithostratigraphicTest {
 
-  @Mock
-  private ArchiveFile archiveFile;
-  @Mock
-  private Record rec;
-
   private static Stream<Arguments> dwcArguments() {
     return Stream.of(
-        Arguments.of(new Bed(), "Harlem coal", "dwc:bed", DwcTerm.bed),
-        Arguments.of(new Formation(), "Fillmore Formation", "dwc:formation", DwcTerm.formation),
-        Arguments.of(new Group(), "Hellnmaria Member", "dwc:group", DwcTerm.group),
-        Arguments.of(new Member(), "Bathurst", "dwc:member", DwcTerm.member)
+        Arguments.of(new Bed(), "Harlem coal", "dwc:bed"),
+        Arguments.of(new Formation(), "Fillmore Formation", "dwc:formation"),
+        Arguments.of(new Group(), "Hellnmaria Member", "dwc:group"),
+        Arguments.of(new Member(), "Bathurst", "dwc:member")
     );
   }
 
@@ -62,7 +52,7 @@ class LithostratigraphicTest {
         Arguments.of(new Group(), "Hellnmaria Member",
             List.of(Pair.of(
                 "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/lithostratigraphicAttributions/lithostratigraphicAttribution/0/group",
-                    "Hellnmaria Member"))),
+                "Hellnmaria Member"))),
         Arguments.of(new Member(), "Bathurst",
             List.of(Pair.of(
                 "abcd-efg:earthScienceSpecimen/unitStratigraphicDetermination/lithostratigraphicAttributions/lithostratigraphicAttribution/0/member",
@@ -90,15 +80,13 @@ class LithostratigraphicTest {
 
   @ParameterizedTest
   @MethodSource("dwcArguments")
-  void testRetrieveFromDWCA(Term term, String expected, String dwc,
-      org.gbif.dwc.terms.Term dwcTerm) {
+  void testRetrieveFromDWCA(Term term, String expected, String dwc) {
     // Given
-    var archiveField = new ArchiveField(0, dwcTerm);
-    given(archiveFile.getField(dwc)).willReturn(archiveField);
-    given(rec.value(archiveField.getTerm())).willReturn(expected);
+    var unit = new ObjectMapper().createObjectNode();
+    unit.put(dwc, expected);
 
     // When
-    var result = term.retrieveFromDWCA(archiveFile, rec);
+    var result = term.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo(expected);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/stratigraphy/LithostratigraphicTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/stratigraphy/LithostratigraphicTest.java
@@ -3,7 +3,6 @@ package eu.dissco.core.translator.terms.specimen.stratigraphy;
 import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.translator.terms.Term;
 import eu.dissco.core.translator.terms.specimen.stratigraphy.lithostratigraphic.Bed;
 import eu.dissco.core.translator.terms.specimen.stratigraphy.lithostratigraphic.Formation;
@@ -82,7 +81,7 @@ class LithostratigraphicTest {
   @MethodSource("dwcArguments")
   void testRetrieveFromDWCA(Term term, String expected, String dwc) {
     // Given
-    var unit = new ObjectMapper().createObjectNode();
+    var unit = MAPPER.createObjectNode();
     unit.put(dwc, expected);
 
     // When


### PR DESCRIPTION
Rework of the DWCA ingestion.
When a new DWCA is ingested we take the following steps:
- Download DWCA and store locally
- Create database tables for core and all extensions
- Run through files and insert record (dwcaId, JSON) into database
- Retrieve batch of 10.000 core records from database
- Attach all extension to record by querying all extension tables
- Publish digital specimen record
- Publish any attached media record
- Drop created tables

Additionally:
- Check extensions in `hasMedia` 
- Check Identification extension for `typeStatus`
- Util method to create `physicalSpecimenId`

Related user stories:
- https://naturalis.atlassian.net/browse/DD-301
- https://naturalis.atlassian.net/browse/DD-263
- https://naturalis.atlassian.net/browse/DD-264
