### PR TITLE
Several improvements to mapping

### DIFF
--- a/src/main/java/eu/dissco/core/translator/component/MappingComponent.java
+++ b/src/main/java/eu/dissco/core/translator/component/MappingComponent.java
@@ -6,7 +6,6 @@ import eu.dissco.core.translator.repository.MappingRepository;
 import jakarta.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.Map;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/src/main/java/eu/dissco/core/translator/service/DwcaService.java
+++ b/src/main/java/eu/dissco/core/translator/service/DwcaService.java
@@ -236,12 +236,13 @@ public class DwcaService implements WebClientService {
         getPhysicalSpecimenId(physicalSpecimenIdType, organisationId, physicalSpecimenId),
         termMapper.retrieveFromDWCA(new Type(), fullRecord),
         harmonizeSpecimenAttributes(physicalSpecimenIdType, organisationId, fullRecord),
-        removeMedia(fullRecord)
+        cleanupRedundantFields(fullRecord)
     );
   }
 
-  private JsonNode removeMedia(JsonNode fullRecord) {
-    var originalData = fullRecord.deepCopy();
+  private JsonNode cleanupRedundantFields(JsonNode fullRecord) {
+    var originalData = (ObjectNode) fullRecord.deepCopy();
+    originalData.remove("ods:taxonIdentificationIndex");
     ObjectNode extensions = (ObjectNode) originalData.get(EXTENSIONS);
     if (extensions != null){
       extensions.remove(List.of(GBIF_MULTIMEDIA, AC_MULTIMEDIA));

--- a/src/main/java/eu/dissco/core/translator/service/KafkaService.java
+++ b/src/main/java/eu/dissco/core/translator/service/KafkaService.java
@@ -6,8 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Service;
-import org.springframework.util.concurrent.ListenableFuture;
-import org.springframework.util.concurrent.ListenableFutureCallback;
 
 @Service
 @Slf4j

--- a/src/main/java/eu/dissco/core/translator/terms/License.java
+++ b/src/main/java/eu/dissco/core/translator/terms/License.java
@@ -1,7 +1,6 @@
 package eu.dissco.core.translator.terms;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import efg.DataSets.DataSet;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
@@ -10,28 +9,24 @@ public class License extends Term {
 
   public static final String TERM = "dcterms:license";
   private final List<String> dwcaTerms = List.of(TERM, "dc:license");
+  private final List<String> abcdUnitTerms = List.of("abcd:iprstatements/licenses/license/0/uri",
+      "abcd:iprstatements/licenses/license/0/text");
+  private final List<String> abcdMetaTerms = List.of(
+      "abcd:metadata/iprstatements/licenses/license/0/uri",
+      "abcd:metadata/iprstatements/licenses/license/0/text");
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
-  public String retrieveFromABCD(DataSet datasets) {
-    if (datasets != null && datasets.getMetadata() != null
-        && datasets.getMetadata().getIPRStatements() != null
-        && datasets.getMetadata().getIPRStatements().getLicenses() != null
-        && !datasets.getMetadata().getIPRStatements().getLicenses().getLicense().isEmpty()) {
-      var license = datasets.getMetadata().getIPRStatements().getLicenses().getLicense().get(0)
-          .getURI();
-      if (license == null) {
-        license = datasets.getMetadata().getIPRStatements().getLicenses().getLicense().get(0)
-            .getText();
-      }
-      return license;
+  public String retrieveFromABCD(JsonNode dataset, JsonNode unit) {
+    var license = searchJsonForStringTerm(unit, abcdUnitTerms);
+    if (license == null) {
+      license = searchJsonForStringTerm(dataset, abcdMetaTerms);
     }
-    log.info("Unable to get license for dataset");
-    return null;
+    return license;
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/Term.java
+++ b/src/main/java/eu/dissco/core/translator/terms/Term.java
@@ -2,7 +2,6 @@ package eu.dissco.core.translator.terms;
 
 
 import com.fasterxml.jackson.databind.JsonNode;
-import efg.DataSets.DataSet;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
@@ -14,11 +13,23 @@ public abstract class Term {
   protected static final String DWC_PREFIX = "dwc:";
   private static final String MESSAGE = "No specific attributes retrieve specified for field: {}";
 
-  protected String searchJsonForTerm(JsonNode attributes, List<String> originalTerms) {
+  protected String searchJsonForStringTerm(JsonNode attributes, List<String> originalTerms) {
     for (var originalTerm : originalTerms) {
       var valueNode = attributes.get(originalTerm);
       if (valueNode != null && valueNode.isTextual()) {
         return attributes.get(originalTerm).asText();
+      }
+    }
+    log.debug("Term not found in any of these search fields: {}", originalTerms);
+    return null;
+  }
+
+  protected String searchJsonForLongTerm(JsonNode attributes, List<String> originalTerms) {
+    for (var originalTerm : originalTerms) {
+      var valueNode = attributes.get(originalTerm);
+      if (valueNode != null && valueNode.isLong()) {
+        var longValue = attributes.get(originalTerm).asLong();
+        return String.valueOf(longValue);
       }
     }
     log.debug("Term not found in any of these search fields: {}", originalTerms);
@@ -49,7 +60,7 @@ public abstract class Term {
     return null;
   }
 
-  public String retrieveFromABCD(DataSet datasets) {
+  public String retrieveFromABCD(JsonNode dataset, JsonNode unit) {
     log.debug(MESSAGE, getTerm());
     return null;
   }

--- a/src/main/java/eu/dissco/core/translator/terms/TermMapper.java
+++ b/src/main/java/eu/dissco/core/translator/terms/TermMapper.java
@@ -1,10 +1,8 @@
 package eu.dissco.core.translator.terms;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import efg.DataSets.DataSet;
 import eu.dissco.core.translator.component.MappingComponent;
 import eu.dissco.core.translator.terms.specimen.BasisOfRecord;
-import eu.dissco.core.translator.terms.specimen.TopicDiscipline;
 import eu.dissco.core.translator.terms.specimen.CollectingNumber;
 import eu.dissco.core.translator.terms.specimen.Collector;
 import eu.dissco.core.translator.terms.specimen.DatasetId;
@@ -14,7 +12,7 @@ import eu.dissco.core.translator.terms.specimen.LivingOrPreserved;
 import eu.dissco.core.translator.terms.specimen.Modified;
 import eu.dissco.core.translator.terms.specimen.ObjectType;
 import eu.dissco.core.translator.terms.specimen.PhysicalSpecimenCollection;
-import eu.dissco.core.translator.terms.specimen.TypeStatus;
+import eu.dissco.core.translator.terms.specimen.TopicDiscipline;
 import eu.dissco.core.translator.terms.specimen.location.Continent;
 import eu.dissco.core.translator.terms.specimen.location.Country;
 import eu.dissco.core.translator.terms.specimen.location.CountryCode;
@@ -54,6 +52,7 @@ import eu.dissco.core.translator.terms.specimen.taxonomy.ScientificNameAuthorshi
 import eu.dissco.core.translator.terms.specimen.taxonomy.SpecificEpithet;
 import eu.dissco.core.translator.terms.specimen.taxonomy.SpecimenName;
 import eu.dissco.core.translator.terms.specimen.taxonomy.TaxonRank;
+import eu.dissco.core.translator.terms.specimen.taxonomy.TypeStatus;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -110,7 +109,6 @@ public class TermMapper {
     list.add(new PhysicalSpecimenCollection());
     list.add(new DatasetId());
     list.add(new ObjectType());
-    list.add(new Modified());
     list.add(new DateCollected());
     list.add(new CollectingNumber());
     list.add(new Collector());
@@ -148,6 +146,7 @@ public class TermMapper {
   public static List<Term> dwcaHarmonisedTerms() {
     var terms = harmonisedTerms();
     terms.add(new License());
+    terms.add(new Modified());
     return terms;
   }
 
@@ -177,7 +176,7 @@ public class TermMapper {
     return term.retrieveFromABCD(unit);
   }
 
-  public String retrieveFromABCD(Term term, DataSet datasets) {
-    return term.retrieveFromABCD(datasets);
+  public String retrieveFromABCD(Term term, JsonNode dataset, JsonNode unit) {
+    return term.retrieveFromABCD(dataset, unit);
   }
 }

--- a/src/main/java/eu/dissco/core/translator/terms/media/AccessUri.java
+++ b/src/main/java/eu/dissco/core/translator/terms/media/AccessUri.java
@@ -12,12 +12,12 @@ public class AccessUri extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/media/Format.java
+++ b/src/main/java/eu/dissco/core/translator/terms/media/Format.java
@@ -14,12 +14,12 @@ public class Format extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/media/MediaType.java
+++ b/src/main/java/eu/dissco/core/translator/terms/media/MediaType.java
@@ -17,7 +17,7 @@ public class MediaType extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    var recoveredType = super.searchJsonForTerm(unit, dwcaTerms);
+    var recoveredType = super.searchJsonForStringTerm(unit, dwcaTerms);
     if (recoveredType == null) {
       var format = new Format().retrieveFromDWCA(unit);
       return checkFormat(format);

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/BasisOfRecord.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/BasisOfRecord.java
@@ -13,12 +13,12 @@ public class BasisOfRecord extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/CollectingNumber.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/CollectingNumber.java
@@ -14,12 +14,12 @@ public class CollectingNumber extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/Collector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/Collector.java
@@ -16,7 +16,7 @@ public class Collector extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/DatasetId.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/DatasetId.java
@@ -12,7 +12,7 @@ public class DatasetId extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/DateCollected.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/DateCollected.java
@@ -9,17 +9,17 @@ public class DateCollected extends Term {
   public static final String TERM = ODS_PREFIX + "dateCollected";
 
   private final List<String> dwcaTerms = List.of("dwc:eventDate");
-  private final List<String> abcdTerms = List.of("abcd:gathering/dateTime/isodateTimeStart",
+  private final List<String> abcdTerms = List.of("abcd:gathering/dateTime/isodateTimeBegin",
       "abcd:gathering/dateTime/isodateTimeEnd", "abcd:gathering/dateTime/dateText");
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/HasMedia.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/HasMedia.java
@@ -17,7 +17,7 @@ public class HasMedia extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    var result = super.searchJsonForTerm(unit, dwcaTerms);
+    var result = super.searchJsonForStringTerm(unit, dwcaTerms);
     if (result != null) {
       return String.valueOf(true);
     } else if (unit.get("extensions") != null) {
@@ -36,7 +36,7 @@ public class HasMedia extends Term {
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    var result = super.searchJsonForTerm(unit, abcdTerms);
+    var result = super.searchJsonForStringTerm(unit, abcdTerms);
     return toBoolean(result);
   }
 

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/Modified.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/Modified.java
@@ -19,13 +19,13 @@ public class Modified extends Term {
   @Override
   public String retrieveFromABCD(JsonNode dataset, JsonNode unit) {
     var modified = searchJsonForStringTerm(unit, abcdUnitTerms);
-    if (modified == null){
+    if (modified == null) {
       modified = searchJsonForLongTerm(unit, abcdUnitTerms);
     }
-    if (modified == null){
+    if (modified == null) {
       modified = searchJsonForStringTerm(dataset, abcdMetaTerms);
     }
-    if (modified == null){
+    if (modified == null) {
       modified = searchJsonForLongTerm(dataset, abcdMetaTerms);
     }
     return modified;

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/Modified.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/Modified.java
@@ -8,16 +8,27 @@ public class Modified extends Term {
 
   public static final String TERM = "dcterms:modified";
   private final List<String> dwcaTerms = List.of(TERM);
-  private final List<String> abcdTerms = List.of("abcd:hasDateModified", "abcd:dateLastEdited");
+  private final List<String> abcdMetaTerms = List.of("abcd:metadata/revisionData/dateModified");
+  private final List<String> abcdUnitTerms = List.of("abcd:hasDateModified", "abcd:dateLastEdited");
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
-  public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+  public String retrieveFromABCD(JsonNode dataset, JsonNode unit) {
+    var modified = searchJsonForStringTerm(unit, abcdUnitTerms);
+    if (modified == null){
+      modified = searchJsonForLongTerm(unit, abcdUnitTerms);
+    }
+    if (modified == null){
+      modified = searchJsonForStringTerm(dataset, abcdMetaTerms);
+    }
+    if (modified == null){
+      modified = searchJsonForLongTerm(dataset, abcdMetaTerms);
+    }
+    return modified;
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/ObjectType.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/ObjectType.java
@@ -12,12 +12,12 @@ public class ObjectType extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenCollection.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenCollection.java
@@ -12,7 +12,7 @@ public class PhysicalSpecimenCollection extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenId.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/PhysicalSpecimenId.java
@@ -13,12 +13,12 @@ public class PhysicalSpecimenId extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/Continent.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/Continent.java
@@ -11,7 +11,7 @@ public class Continent extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/Country.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/Country.java
@@ -15,12 +15,12 @@ public class Country extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/CountryCode.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/CountryCode.java
@@ -14,12 +14,12 @@ public class CountryCode extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/County.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/County.java
@@ -11,7 +11,7 @@ public class County extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/DecimalLatitude.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/DecimalLatitude.java
@@ -9,17 +9,20 @@ public class DecimalLatitude extends Term {
   public static final String TERM = DWC_PREFIX + "decimalLatitude";
 
   private final List<String> dwcaTerms = List.of(TERM);
-  private final List<String> abcdTerms = List.of(
-      "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/latitudeDecimal");
+  private final String abcdTerm = "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/latitudeDecimal";
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    var latitude = unit.get(abcdTerm);
+    if (latitude != null && latitude.isDouble()) {
+      return String.valueOf(latitude.asDouble());
+    }
+    return null;
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/DecimalLatitude.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/DecimalLatitude.java
@@ -7,9 +7,8 @@ import java.util.List;
 public class DecimalLatitude extends Term {
 
   public static final String TERM = DWC_PREFIX + "decimalLatitude";
-
+  private static final String ABCD_TERM = "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/latitudeDecimal";
   private final List<String> dwcaTerms = List.of(TERM);
-  private final String abcdTerm = "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/latitudeDecimal";
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
@@ -18,7 +17,7 @@ public class DecimalLatitude extends Term {
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    var latitude = unit.get(abcdTerm);
+    var latitude = unit.get(ABCD_TERM);
     if (latitude != null && latitude.isDouble()) {
       return String.valueOf(latitude.asDouble());
     }

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/DecimalLongitude.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/DecimalLongitude.java
@@ -7,9 +7,8 @@ import java.util.List;
 public class DecimalLongitude extends Term {
 
   public static final String TERM = DWC_PREFIX + "decimalLongitude";
-
+  private static final String ABCD_TERM = "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/longitudeDecimal";
   private final List<String> dwcaTerms = List.of(TERM);
-  private final String abcdTerm = "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/longitudeDecimal";
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
@@ -18,7 +17,7 @@ public class DecimalLongitude extends Term {
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    var longitude = unit.get(abcdTerm);
+    var longitude = unit.get(ABCD_TERM);
     if (longitude != null && longitude.isDouble()) {
       return String.valueOf(longitude.asDouble());
     }

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/DecimalLongitude.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/DecimalLongitude.java
@@ -9,17 +9,20 @@ public class DecimalLongitude extends Term {
   public static final String TERM = DWC_PREFIX + "decimalLongitude";
 
   private final List<String> dwcaTerms = List.of(TERM);
-  private final List<String> abcdTerms = List.of(
-      "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/longitudeDecimal");
+  private final String abcdTerm = "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/longitudeDecimal";
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    var longitude = unit.get(abcdTerm);
+    if (longitude != null && longitude.isDouble()) {
+      return String.valueOf(longitude.asDouble());
+    }
+    return null;
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/GeodeticDatum.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/GeodeticDatum.java
@@ -14,12 +14,12 @@ public class GeodeticDatum extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/Island.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/Island.java
@@ -11,7 +11,7 @@ public class Island extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/IslandGroup.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/IslandGroup.java
@@ -11,7 +11,7 @@ public class IslandGroup extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/Locality.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/Locality.java
@@ -13,12 +13,12 @@ public class Locality extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/Municipality.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/Municipality.java
@@ -11,7 +11,7 @@ public class Municipality extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/StateProvince.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/StateProvince.java
@@ -11,7 +11,7 @@ public class StateProvince extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/WaterBody.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/WaterBody.java
@@ -11,7 +11,7 @@ public class WaterBody extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/biostratigraphic/HighestBiostratigraphicZone.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/biostratigraphic/HighestBiostratigraphicZone.java
@@ -16,7 +16,7 @@ public class HighestBiostratigraphicZone extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/biostratigraphic/LowestBiostratigraphicZone.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/biostratigraphic/LowestBiostratigraphicZone.java
@@ -16,7 +16,7 @@ public class LowestBiostratigraphicZone extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestAgeOrLowestStage.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestAgeOrLowestStage.java
@@ -10,7 +10,7 @@ public class EarliestAgeOrLowestStage extends AbstractChronoStratigraphy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestEonOrLowestEonothem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestEonOrLowestEonothem.java
@@ -10,7 +10,7 @@ public class EarliestEonOrLowestEonothem extends AbstractChronoStratigraphy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestEpochOrLowestSeries.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestEpochOrLowestSeries.java
@@ -10,7 +10,7 @@ public class EarliestEpochOrLowestSeries extends AbstractChronoStratigraphy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestEraOrLowestErathem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestEraOrLowestErathem.java
@@ -10,7 +10,7 @@ public class EarliestEraOrLowestErathem extends AbstractChronoStratigraphy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestPeriodOrLowestSystem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/EarliestPeriodOrLowestSystem.java
@@ -10,7 +10,7 @@ public class EarliestPeriodOrLowestSystem extends AbstractChronoStratigraphy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestAgeOrHighestStage.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestAgeOrHighestStage.java
@@ -10,7 +10,7 @@ public class LatestAgeOrHighestStage extends AbstractChronoStratigraphy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestEonOrHighestEonothem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestEonOrHighestEonothem.java
@@ -10,7 +10,7 @@ public class LatestEonOrHighestEonothem extends AbstractChronoStratigraphy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestEpochOrHighestSeries.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestEpochOrHighestSeries.java
@@ -10,7 +10,7 @@ public class LatestEpochOrHighestSeries extends AbstractChronoStratigraphy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestEraOrHighestErathem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestEraOrHighestErathem.java
@@ -10,7 +10,7 @@ public class LatestEraOrHighestErathem extends AbstractChronoStratigraphy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestPeriodOrHighestSystem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/chronostratigraphic/LatestPeriodOrHighestSystem.java
@@ -10,7 +10,7 @@ public class LatestPeriodOrHighestSystem extends AbstractChronoStratigraphy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Bed.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Bed.java
@@ -15,12 +15,12 @@ public class Bed extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Formation.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Formation.java
@@ -15,12 +15,12 @@ public class Formation extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Group.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Group.java
@@ -15,12 +15,12 @@ public class Group extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Member.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/stratigraphy/lithostratigraphic/Member.java
@@ -15,12 +15,12 @@ public class Member extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.searchJsonForStringTerm(unit, dwcaTerms);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    return super.searchJsonForStringTerm(unit, abcdTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/AbstractTaxonomy.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/AbstractTaxonomy.java
@@ -10,8 +10,11 @@ import org.apache.commons.lang3.tuple.Triple;
 
 public abstract class AbstractTaxonomy extends Term {
 
-  private static final String IDENTIFICATION = "abcd:identifications/identification/";
+  protected static final String IDENTIFICATION = "abcd:identifications/identification/";
   private static final String IDENTIFICATION_INDEX = "ods:taxonIdentificationIndex";
+  protected static final String EXTENSIONS = "extensions";
+  protected static final String IDENTIFICATION_EXTENSION = "dwc:Identification";
+  protected static final String IDENTIFICATION_VERIFICATION_STATUS = "dwc:identificationVerificationStatus";
   private static final Triple<String, String, String> ABCD_TAXON_RANK =
       Triple.of(
           IDENTIFICATION,
@@ -25,18 +28,66 @@ public abstract class AbstractTaxonomy extends Term {
   private static final Pair<String, String> abcdPreferredFlag = Pair.of(IDENTIFICATION,
       "/preferredFlag");
 
+  protected String getTaxonFromDWCA(JsonNode unit, List<String> dwcaTerms) {
+    var result = super.searchJsonForStringTerm(unit, dwcaTerms);
+    if (result != null) {
+      return result;
+    } else if (unit.get(EXTENSIONS) != null
+        && unit.get(EXTENSIONS).get(IDENTIFICATION_EXTENSION) != null) {
+      var identificationIndex = getIdentificationIndexDWCA(unit);
+      if (identificationIndex != null) {
+        return searchJsonForStringTerm(
+            unit.get(EXTENSIONS).get(IDENTIFICATION_EXTENSION)
+                .get(Integer.parseInt(identificationIndex)), dwcaTerms);
+      }
+    }
+    return null;
+  }
+  private Optional<String> determineIdentificationIndexDWCA(JsonNode unit) {
+    if (unit.get(EXTENSIONS) != null
+        && unit.get(EXTENSIONS).get(IDENTIFICATION_EXTENSION) != null) {
+      var identifications = unit.get(EXTENSIONS).get(IDENTIFICATION_EXTENSION);
+      for (int i = 0; i < identifications.size(); i++) {
+        var identification = identifications.get(i);
+        if (identification.get(IDENTIFICATION_VERIFICATION_STATUS) == null) {
+          return Optional.of(String.valueOf(i));
+        } else {
+          var verificationStatus = identification.get(IDENTIFICATION_VERIFICATION_STATUS)
+              .asText();
+          if (verificationStatus.equals("1")) {
+            return Optional.of(String.valueOf(i));
+          }
+        }
+      }
+    }
+    return Optional.empty();
+  }
 
-  protected String getIdentificationIndex(JsonNode unit) {
+  protected String getIdentificationIndexDWCA(JsonNode unit) {
     if (unit.get(IDENTIFICATION_INDEX) != null) {
       return unit.get(IDENTIFICATION_INDEX).asText();
     } else {
-      var identificationIndex = determineIdentificationIndex(unit);
+      var optionalIndex = determineIdentificationIndexDWCA(unit);
+      if (optionalIndex.isPresent()) {
+        ((ObjectNode) unit).put(IDENTIFICATION_INDEX, optionalIndex.get());
+        return optionalIndex.get();
+      } else {
+        return null;
+      }
+    }
+  }
+
+  protected String getIdentificationIndexABCD(JsonNode unit) {
+    if (unit.get(IDENTIFICATION_INDEX) != null) {
+      return unit.get(IDENTIFICATION_INDEX).asText();
+    } else {
+      var identificationIndex = determineIdentificationIndexABCD(unit);
       ((ObjectNode) unit).put(IDENTIFICATION_INDEX, identificationIndex);
       return identificationIndex;
     }
   }
 
-  private String determineIdentificationIndex(JsonNode unit) {
+  private String determineIdentificationIndexABCD(JsonNode unit) {
     var numberFound = 0;
     while (true) {
       if (unit.get(getStringAtIndex(abcdPreferredFlag, numberFound)) != null) {
@@ -53,7 +104,7 @@ public abstract class AbstractTaxonomy extends Term {
   }
 
   protected String searchABCDSplitTerms(JsonNode unit, List<String> searchTerms) {
-    var identificationIndex = getIdentificationIndex(unit);
+    var identificationIndex = getIdentificationIndexABCD(unit);
     return searchABCDSplitTerms(unit, searchTerms,
         Pair.of(ABCD_TAXON_RANK.getLeft() + identificationIndex + ABCD_TAXON_RANK.getMiddle(),
             ABCD_TAXON_RANK.getRight()),
@@ -62,10 +113,10 @@ public abstract class AbstractTaxonomy extends Term {
   }
 
   protected String searchABCDTerms(JsonNode unit, List<String> searchTerms) {
-    var identificationIndex = getIdentificationIndex(unit);
+    var identificationIndex = getIdentificationIndexABCD(unit);
     var terms = searchTerms.stream().map(
         term -> IDENTIFICATION + identificationIndex + "/result/taxonIdentified" + term).toList();
-    return searchJsonForTerm(unit, terms);
+    return searchJsonForStringTerm(unit, terms);
   }
 
   protected String getStringAtIndex(Pair<String, String> string, int numberFound) {

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/AbstractTaxonomy.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/AbstractTaxonomy.java
@@ -11,10 +11,10 @@ import org.apache.commons.lang3.tuple.Triple;
 public abstract class AbstractTaxonomy extends Term {
 
   protected static final String IDENTIFICATION = "abcd:identifications/identification/";
-  private static final String IDENTIFICATION_INDEX = "ods:taxonIdentificationIndex";
   protected static final String EXTENSIONS = "extensions";
   protected static final String IDENTIFICATION_EXTENSION = "dwc:Identification";
   protected static final String IDENTIFICATION_VERIFICATION_STATUS = "dwc:identificationVerificationStatus";
+  private static final String IDENTIFICATION_INDEX = "ods:taxonIdentificationIndex";
   private static final Triple<String, String, String> ABCD_TAXON_RANK =
       Triple.of(
           IDENTIFICATION,
@@ -43,6 +43,7 @@ public abstract class AbstractTaxonomy extends Term {
     }
     return null;
   }
+
   private Optional<String> determineIdentificationIndexDWCA(JsonNode unit) {
     if (unit.get(EXTENSIONS) != null
         && unit.get(EXTENSIONS).get(IDENTIFICATION_EXTENSION) != null) {

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/Class.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/Class.java
@@ -11,7 +11,7 @@ public class Class extends AbstractTaxonomy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.getTaxonFromDWCA(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/Family.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/Family.java
@@ -11,7 +11,7 @@ public class Family extends AbstractTaxonomy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.getTaxonFromDWCA(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/Genus.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/Genus.java
@@ -11,7 +11,7 @@ public class Genus extends AbstractTaxonomy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.getTaxonFromDWCA(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/InfraspecificEpithet.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/InfraspecificEpithet.java
@@ -12,7 +12,7 @@ public class InfraspecificEpithet extends AbstractTaxonomy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.getTaxonFromDWCA(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/Kingdom.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/Kingdom.java
@@ -11,7 +11,7 @@ public class Kingdom extends AbstractTaxonomy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.getTaxonFromDWCA(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/Order.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/Order.java
@@ -11,7 +11,7 @@ public class Order extends AbstractTaxonomy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.getTaxonFromDWCA(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/Phylum.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/Phylum.java
@@ -11,7 +11,7 @@ public class Phylum extends AbstractTaxonomy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.getTaxonFromDWCA(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/ScientificNameAuthorship.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/ScientificNameAuthorship.java
@@ -11,7 +11,7 @@ public class ScientificNameAuthorship extends AbstractTaxonomy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.getTaxonFromDWCA(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/SpecificEpithet.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/SpecificEpithet.java
@@ -11,7 +11,7 @@ public class SpecificEpithet extends AbstractTaxonomy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.getTaxonFromDWCA(unit, dwcaTerms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/SpecimenName.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/SpecimenName.java
@@ -11,24 +11,27 @@ public class SpecimenName extends AbstractTaxonomy {
   public static final String TERM = ODS_PREFIX + "specimenName";
   private final List<String> dwcaTerms = List.of("dwc:scientificName");
   private final List<Pair<String, String>> abcdTerms = List.of(
-      Pair.of("abcd:identifications/identification/",
-          "/result/taxonIdentified/scientificName/fullScientificNameString"),
+      Pair.of(IDENTIFICATION, "/result/taxonIdentified/scientificName/fullScientificNameString"),
       Pair.of("abcd-efg:identifications/identification/",
-          "/result/mineralRockIdentified/classifiedName/fullScientificNameString")
+          "/result/mineralRockIdentified/classifiedName/fullScientificNameString"),
+      Pair.of(IDENTIFICATION, "result/taxonIdentified/informalNameString"),
+      Pair.of(IDENTIFICATION,
+          "result/taxonIdentified/scientificName/nameAtomised/zoological/namedIndividual")
   );
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.getTaxonFromDWCA(unit, dwcaTerms);
   }
+
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    var identificationIndex = getIdentificationIndex(unit);
+    var identificationIndex = getIdentificationIndexABCD(unit);
     var terms = abcdTerms.stream()
         .map(abcdTerm -> getStringAtIndex(abcdTerm, Integer.parseInt(identificationIndex)))
         .toList();
-    return searchJsonForTerm(unit, terms);
+    return searchJsonForStringTerm(unit, terms);
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/TaxonRank.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/TaxonRank.java
@@ -14,12 +14,8 @@ public class TaxonRank extends AbstractTaxonomy {
     return super.getTaxonFromDWCA(unit, dwcaTerms);
   }
 
-
-
   @Override
   public String getTerm() {
     return TERM;
   }
-
-
 }

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/TaxonRank.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/TaxonRank.java
@@ -11,8 +11,10 @@ public class TaxonRank extends AbstractTaxonomy {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    return super.getTaxonFromDWCA(unit, dwcaTerms);
   }
+
+
 
   @Override
   public String getTerm() {

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/TypeStatus.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/taxonomy/TypeStatus.java
@@ -1,10 +1,9 @@
-package eu.dissco.core.translator.terms.specimen;
+package eu.dissco.core.translator.terms.specimen.taxonomy;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import eu.dissco.core.translator.terms.Term;
 import java.util.List;
 
-public class TypeStatus extends Term {
+public class TypeStatus extends AbstractTaxonomy {
 
   public static final String TERM = DWC_PREFIX + "typeStatus";
 
@@ -20,19 +19,7 @@ public class TypeStatus extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    var result = super.searchJsonForTerm(unit, dwcaTerms);
-    if (result != null) {
-      return result;
-    } else {
-      var extensions = unit.get("extensions");
-      if (extensions != null) {
-        var identification = extensions.get("dwc:Identification");
-        if (identification != null && identification.size() == 1) {
-          return searchJsonForTerm(identification.get(0), dwcaTerms);
-        }
-      }
-    }
-    return null;
+    return super.getTaxonFromDWCA(unit, dwcaTerms);
   }
 
   @Override

--- a/src/test/java/eu/dissco/core/translator/terms/LicenseTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/LicenseTest.java
@@ -15,76 +15,50 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class LicenseTest {
 
-  private final License license = new License();
+  private static final String LICENSE_STRING = "https://creativecommons.org/licenses/by-nc/4.0";
 
-  private static DataSet getDataSet(String licenseString, boolean useUri) {
-    var dataset = new DataSet();
-    var metadata = new ContentMetadata();
-    var ipr = new IPRStatements();
-    var licenseElement = new Licenses();
-    var statement = new Statement();
-    if (useUri) {
-      statement.setURI(licenseString);
-    } else {
-      statement.setText(licenseString);
-    }
-    licenseElement.getLicense().add(statement);
-    ipr.setLicenses(licenseElement);
-    metadata.setIPRStatements(ipr);
-    dataset.setMetadata(metadata);
-    return dataset;
-  }
+  private final License license = new License();
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var licenseString = "https://creativecommons.org/licenses/by-nc/4.0";
     var unit = MAPPER.createObjectNode();
-    unit.put("dcterms:license", licenseString);
+    unit.put("dcterms:license", LICENSE_STRING);
 
     // When
     var result = license.retrieveFromDWCA(unit);
 
     // Then
-    assertThat(result).isEqualTo(licenseString);
+    assertThat(result).isEqualTo(LICENSE_STRING);
   }
 
   @Test
-  void testRetrieveFromABCDUri() {
+  void testRetrieveFromABCD() {
     // Given
-    var licenseString = "https://creativecommons.org/licenses/by-nc/4.0";
-    DataSet dataset = getDataSet(licenseString, true);
+    var dataset = MAPPER.createObjectNode();
+    dataset.put("abcd:metadata/iprstatements/licenses/license/0/uri", "Another License");
+    var unit = MAPPER.createObjectNode();
+    unit.put("abcd:iprstatements/licenses/license/0/uri", LICENSE_STRING);
 
     // When
-    var result = license.retrieveFromABCD(dataset);
+    var result = license.retrieveFromABCD(dataset, unit);
 
     // Then
-    assertThat(result).isEqualTo(licenseString);
+    assertThat(result).isEqualTo(LICENSE_STRING);
   }
 
   @Test
-  void testRetrieveFromABCDText() {
+  void testRetrieveFromABCDMetadata() {
     // Given
-    var licenseString = "https://creativecommons.org/licenses/by-nc/4.0";
-    DataSet dataset = getDataSet(licenseString, false);
+    var dataset = MAPPER.createObjectNode();
+    dataset.put("abcd:metadata/iprstatements/licenses/license/0/text", "Another License");
+    var unit = MAPPER.createObjectNode();
 
     // When
-    var result = license.retrieveFromABCD(dataset);
+    var result = license.retrieveFromABCD(dataset, unit);
 
     // Then
-    assertThat(result).isEqualTo(licenseString);
-  }
-
-  @Test
-  void testRetrieveFromABCDEmpty() {
-    // Given
-    DataSet dataset = new DataSet();
-
-    // When
-    var result = license.retrieveFromABCD(dataset);
-
-    // Then
-    assertThat(result).isNull();
+    assertThat(result).isEqualTo("Another License");
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/translator/terms/TermMapperTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/TermMapperTest.java
@@ -121,17 +121,17 @@ class TermMapperTest {
     then(physicalSpecimenCollection).should().retrieveFromABCD(attributes);
   }
 
-  @Test
-  void testRetrieveFromABCDNoMappingHeader() {
-    // Given
-    var physicalSpecimenCollection = mock(PhysicalSpecimenCollection.class);
-    var dataset = mock(DataSet.class);
-
-    // When
-    termMapper.retrieveFromABCD(physicalSpecimenCollection, dataset);
-
-    // Then
-    then(physicalSpecimenCollection).should().retrieveFromABCD(dataset);
-  }
+//  @Test
+//  void testRetrieveFromABCDNoMappingHeader() {
+//    // Given
+//    var physicalSpecimenCollection = mock(PhysicalSpecimenCollection.class);
+//    var dataset = mock(DataSet.class);
+//
+//    // When
+//    termMapper.retrieveFromABCD(physicalSpecimenCollection, dataset);
+//
+//    // Then
+//    then(physicalSpecimenCollection).should().retrieveFromABCD(dataset);
+//  }
 
 }

--- a/src/test/java/eu/dissco/core/translator/terms/TermMapperTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/TermMapperTest.java
@@ -121,17 +121,4 @@ class TermMapperTest {
     then(physicalSpecimenCollection).should().retrieveFromABCD(attributes);
   }
 
-//  @Test
-//  void testRetrieveFromABCDNoMappingHeader() {
-//    // Given
-//    var physicalSpecimenCollection = mock(PhysicalSpecimenCollection.class);
-//    var dataset = mock(DataSet.class);
-//
-//    // When
-//    termMapper.retrieveFromABCD(physicalSpecimenCollection, dataset);
-//
-//    // Then
-//    then(physicalSpecimenCollection).should().retrieveFromABCD(dataset);
-//  }
-
 }

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/DateCollectedTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/DateCollectedTest.java
@@ -31,7 +31,7 @@ class DateCollectedTest {
   void testRetrieveFromABCD() {
     // Given
     var unit = MAPPER.createObjectNode();
-    unit.put("abcd:gathering/dateTime/isodateTimeStart", DATE);
+    unit.put("abcd:gathering/dateTime/isodateTimeBegin", DATE);
 
     // When
     var result = dateCollected.retrieveFromABCD(unit);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/ModifiedTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/ModifiedTest.java
@@ -30,14 +30,44 @@ class ModifiedTest {
   void testRetrieveFromABCD() {
     // Given
     String modifiedString = "1674553668909";
+    var dataset = MAPPER.createObjectNode();
+    dataset.put("abcd:metadata/revisionData/dateModified", "1604521759000");
     var unit = MAPPER.createObjectNode();
     unit.put("abcd:dateLastEdited", modifiedString);
 
     // When
-    var result = modified.retrieveFromABCD(unit);
+    var result = modified.retrieveFromABCD(dataset, unit);
 
     // Then
     assertThat(result).isEqualTo(modifiedString);
+  }
+
+  @Test
+  void testRetrieveFromABCDFromMeta() {
+    // Given
+    var dataset = MAPPER.createObjectNode();
+    dataset.put("abcd:metadata/revisionData/dateModified", "1604521759000");
+    var unit = MAPPER.createObjectNode();
+
+    // When
+    var result = modified.retrieveFromABCD(dataset, unit);
+
+    // Then
+    assertThat(result).isEqualTo("1604521759000");
+  }
+
+  @Test
+  void testRetrieveFromABCDFromMetaLong() {
+    // Given
+    var dataset = MAPPER.createObjectNode();
+    dataset.put("abcd:metadata/revisionData/dateModified", 1604521759000L);
+    var unit = MAPPER.createObjectNode();
+
+    // When
+    var result = modified.retrieveFromABCD(dataset, unit);
+
+    // Then
+    assertThat(result).isEqualTo("1604521759000");
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/DecimalLatitudeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/DecimalLatitudeTest.java
@@ -33,7 +33,7 @@ class DecimalLatitudeTest {
     var unit = MAPPER.createObjectNode();
     unit.put(
         "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/latitudeDecimal",
-        LATITUDE_STRING);
+        53.33167);
 
     // When
     var result = decimalLatitude.retrieveFromABCD(unit);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/DecimalLongitudeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/DecimalLongitudeTest.java
@@ -33,7 +33,7 @@ class DecimalLongitudeTest {
     var unit = MAPPER.createObjectNode();
     unit.put(
         "abcd:gathering/siteCoordinateSets/siteCoordinates/0/coordinatesLatLong/longitudeDecimal",
-        LONGITUDE_STRING);
+        10.48778);
 
     // When
     var result = decimalLongitude.retrieveFromABCD(unit);

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/taxonomy/FamilyTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/taxonomy/FamilyTest.java
@@ -26,6 +26,25 @@ class FamilyTest {
   }
 
   @Test
+  void testRetrieveFromDWCAExtensionNoVerified() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    var extension = MAPPER.createObjectNode();
+    var identification = MAPPER.createObjectNode();
+    identification.put("dwc:family", "Soricidae");
+    var identifications = MAPPER.createArrayNode();
+    identifications.add(identification);
+    extension.set("dwc:Identification", identifications);
+    unit.set("extensions", extension);
+
+    // When
+    var result = family.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo("Soricidae");
+  }
+
+  @Test
   void testRetrieveFromABCD() {
     // Given
     var unit = MAPPER.createObjectNode();

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/taxonomy/GenusTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/taxonomy/GenusTest.java
@@ -26,6 +26,31 @@ class GenusTest {
   }
 
   @Test
+  void testRetrieveFromDWCAExtensionNoVerified() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    var extension = MAPPER.createObjectNode();
+    var identificationUnverified = MAPPER.createObjectNode();
+    identificationUnverified.put("dwc:genus", "Rhinopoma");
+    identificationUnverified.put("dwc:identificationVerificationStatus", "0");
+    var identificationVerified = MAPPER.createObjectNode();
+    identificationVerified.put("dwc:genus", "Rhinopoma");
+    identificationVerified.put("dwc:identificationVerificationStatus", "1");
+    var identifications = MAPPER.createArrayNode();
+    identifications.add(identificationUnverified);
+    identifications.add(identificationVerified);
+    extension.set("dwc:Identification", identifications);
+    unit.set("extensions", extension);
+    unit.put("ods:taxonIdentificationIndex", "1");
+
+    // When
+    var result = genus.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo("Rhinopoma");
+  }
+
+  @Test
   void testRetrieveFromABCD() {
     // Given
     var unit = MAPPER.createObjectNode();

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/taxonomy/SpecimenNameTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/taxonomy/SpecimenNameTest.java
@@ -27,6 +27,50 @@ class SpecimenNameTest {
   }
 
   @Test
+  void testRetrieveFromDWCAExtension() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    var extension = MAPPER.createObjectNode();
+    var identificationUnverified = MAPPER.createObjectNode();
+    identificationUnverified.put("dwc:scientificName", "SpecimenNameUnVerified");
+    identificationUnverified.put("dwc:identificationVerificationStatus", "0");
+    var identificationVerified = MAPPER.createObjectNode();
+    identificationVerified.put("dwc:scientificName", "SpecimenNameVerified");
+    identificationVerified.put("dwc:identificationVerificationStatus", "1");
+    var identifications = MAPPER.createArrayNode();
+    identifications.add(identificationVerified);
+    identifications.add(identificationUnverified);
+    extension.set("dwc:Identification", identifications);
+    unit.set("extensions", extension);
+
+    // When
+    var result = specimenName.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo("SpecimenNameVerified");
+  }
+
+  @Test
+  void testRetrieveFromDWCAExtensionNoVerified() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    var extension = MAPPER.createObjectNode();
+    var identificationUnverified = MAPPER.createObjectNode();
+    identificationUnverified.put("dwc:scientificName", "SpecimenNameUnVerified");
+    identificationUnverified.put("dwc:identificationVerificationStatus", "0");
+    var identifications = MAPPER.createArrayNode();
+    identifications.add(identificationUnverified);
+    extension.set("dwc:Identification", identifications);
+    unit.set("extensions", extension);
+
+    // When
+    var result = specimenName.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isNull();
+  }
+
+  @Test
   void testRetrieveFromABCDEFG() {
     // Given
     var specimenNameString = "SpecimenName";

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/taxonomy/TypeStatusTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/taxonomy/TypeStatusTest.java
@@ -1,8 +1,9 @@
-package eu.dissco.core.translator.terms.specimen;
+package eu.dissco.core.translator.terms.specimen.taxonomy;
 
 import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import eu.dissco.core.translator.terms.specimen.taxonomy.TypeStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;


### PR DESCRIPTION
Bunch of improvements for the mapping.
Noticed several issues with ABCD(EFG):
- coordinates are double and weren't picked up
- modified time was in long and wasn't picked up

Fixed differences with David's mapping.
https://naturalis.atlassian.net/browse/DD-445
- Check for modified in metadata
- Check for license in unit data
- Check more fields for specimen name

Able to retrieve tax info for identification extension:
https://naturalis.atlassian.net/browse/DD-495
- When no tax info in core file check extension
- When there is an identificationStatus only take ones that have "1" (ignore others)
- When no identificationStatus take first identification