### PR TITLE
aligned topic discipline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <jaxb2-maven-plugin.version>3.1.0</jaxb2-maven-plugin.version>
     <jakarta.activation-api.version>2.1.0</jakarta.activation-api.version>
     <jakarta.xml.bind-api.version>4.0.0</jakarta.xml.bind-api.version>
+    <spring-kafka.version>3.0.10</spring-kafka.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>
     <testcontainers.version>1.17.5</testcontainers.version>
     <sonar.organization>dissco</sonar.organization>

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/TopicDiscipline.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/TopicDiscipline.java
@@ -21,17 +21,17 @@ public class TopicDiscipline extends Term {
   public String retrieveFromDWCA(JsonNode unit) {
     var basisOfRecord = new BasisOfRecord().retrieveFromDWCA(unit);
     var kingdom = new Kingdom().retrieveFromDWCA(unit);
-    return getCategory(basisOfRecord, kingdom);
+    return getDiscipline(basisOfRecord, kingdom);
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
     var basisOfRecord = new BasisOfRecord().retrieveFromABCD(unit);
     var kingdom = new Kingdom().retrieveFromABCD(unit);
-    return getCategory(basisOfRecord, kingdom);
+    return getDiscipline(basisOfRecord, kingdom);
   }
 
-  private static String getCategory(String basisOfRecord, String kingdom) {
+  private static String getDiscipline(String basisOfRecord, String kingdom) {
     if (basisOfRecord != null) {
       var harBasisOfRecord = basisOfRecord.trim().toUpperCase();
       if (FOSSIL_BASIS_OF_RECORD.contains(harBasisOfRecord)) {
@@ -39,7 +39,7 @@ public class TopicDiscipline extends Term {
       } else if (EXTRATERRESTRIAL_BASIS_OF_RECORD.contains(harBasisOfRecord)) {
         return "Astrogeology";
       } else if (EARTH_SYSTEM_BASIS_OF_RECORD.contains(harBasisOfRecord)){
-        return "Earth System";
+        return "Geology";
       } else if (kingdom != null){
         var harKingdom = kingdom.trim().toUpperCase();
         switch (harKingdom) {

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/TopicDisciplineTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/TopicDisciplineTest.java
@@ -34,7 +34,7 @@ class TopicDisciplineTest {
     return Stream.of(
         Arguments.of("FossilSpecimen", null, "Palaeontology"),
         Arguments.of("MeteoriteSpecimen", null, "Astrogeology"),
-        Arguments.of("RockSpecimen", null, "Earth System"),
+        Arguments.of("RockSpecimen", null, "Geology"),
         Arguments.of("PreservedSpecimen", "Animalia", "Zoology"),
         Arguments.of("PreservedSpecimen", "Plantae", "Botany"),
         Arguments.of("PreservedSpecimen", "Bacteria", "Microbiology"),


### PR DESCRIPTION
Earth system is topic Domain, not topic discipline
Changed `getCategory()` to `getDiscipline()` to reduce ambiguity. `topicCategory()` is its own term. 