### PR TITLE
add mediaHost

### DIFF
--- a/src/main/java/eu/dissco/core/translator/service/BioCaseService.java
+++ b/src/main/java/eu/dissco/core/translator/service/BioCaseService.java
@@ -35,6 +35,7 @@ import eu.dissco.core.translator.terms.Term;
 import eu.dissco.core.translator.terms.TermMapper;
 import eu.dissco.core.translator.terms.media.AccessUri;
 import eu.dissco.core.translator.terms.media.Format;
+import eu.dissco.core.translator.terms.media.MediaHost;
 import eu.dissco.core.translator.terms.media.MediaType;
 import eu.dissco.core.translator.terms.specimen.DwcaId;
 import eu.dissco.core.translator.terms.specimen.Modified;
@@ -210,7 +211,7 @@ public class BioCaseService implements WebClientService {
           kafkaService.sendMessage("digital-specimen",
               mapper.writeValueAsString(
                   new DigitalSpecimenEvent(enrichmentServices(false), digitalSpecimen)));
-          processDigitalMediaObjects(physicalSpecimenId, unit);
+          processDigitalMediaObjects(physicalSpecimenId, unit, organisationId);
         } catch (DiSSCoDataException e) {
           log.error("Encountered data issue with record: {}", unitAttributes, e);
         }
@@ -370,23 +371,23 @@ public class BioCaseService implements WebClientService {
     return data;
   }
 
-  private void processDigitalMediaObjects(String physicalSpecimenId, Unit unit)
+  private void processDigitalMediaObjects(String physicalSpecimenId, Unit unit, String organisationId)
       throws JsonProcessingException {
     if (unit.getMultiMediaObjects() != null && !unit.getMultiMediaObjects().getMultiMediaObject()
         .isEmpty()) {
       for (MultiMediaObject media : unit.getMultiMediaObjects().getMultiMediaObject()) {
-        processDigitalMediaObject(physicalSpecimenId, media);
+        processDigitalMediaObject(physicalSpecimenId, media, organisationId);
       }
     }
   }
 
-  private void processDigitalMediaObject(String physicalSpecimenId, MultiMediaObject media)
+  private void processDigitalMediaObject(String physicalSpecimenId, MultiMediaObject media, String organisationId)
       throws JsonProcessingException {
     var attributes = getData(mapper.valueToTree(media));
     var digitalMediaObject = new DigitalMediaObject(
         termMapper.retrieveFromABCD(new MediaType(), attributes),
         physicalSpecimenId,
-        harmonizeMedia(attributes),
+        harmonizeMedia(attributes, organisationId),
         attributes
     );
     log.debug("Result digital media object: {}", digitalMediaObject);
@@ -395,12 +396,13 @@ public class BioCaseService implements WebClientService {
             new DigitalMediaObjectEvent(enrichmentServices(true), digitalMediaObject)));
   }
 
-  private JsonNode harmonizeMedia(JsonNode mediaAttributes) {
+  private JsonNode harmonizeMedia(JsonNode mediaAttributes, String organisationId) {
     var attributes = mapper.createObjectNode();
     attributes.put(AccessUri.TERM, termMapper.retrieveFromABCD(new AccessUri(), mediaAttributes));
     attributes.put(SourceSystemId.TERM, webClientProperties.getSourceSystemId());
     attributes.put(Format.TERM, termMapper.retrieveFromABCD(new Format(), mediaAttributes));
     attributes.put(License.TERM, termMapper.retrieveFromABCD(new License(), mediaAttributes));
+    attributes.put(MediaHost.TERM, organisationId);
     return attributes;
   }
 

--- a/src/main/java/eu/dissco/core/translator/terms/media/MediaHost.java
+++ b/src/main/java/eu/dissco/core/translator/terms/media/MediaHost.java
@@ -1,0 +1,12 @@
+package eu.dissco.core.translator.terms.media;
+
+import eu.dissco.core.translator.terms.specimen.OrganisationId;
+
+public class MediaHost extends OrganisationId {
+  public static final String TERM = "mediaHost";
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/media/MediaHostTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/media/MediaHostTest.java
@@ -1,0 +1,18 @@
+package eu.dissco.core.translator.terms.media;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MediaHostTest {
+
+  @Test
+  void testGetTerm(){
+    // Given
+    var result = new MediaHost().getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MediaHost.TERM);
+  }
+
+}


### PR DESCRIPTION
Add new term: mediaHost. This term is only for the attribute name; to retrieve the value, we retrieve OrganisationId from the full specimen record. 

We could just use the organisationId for this field instead of creating a new term, but I'd like alignment between the media processor and the handle api. 

Dwca for now