### PR TITLE
Support multiple agents parsing, eventType, media licenses

### DIFF
--- a/src/main/java/eu/dissco/core/translator/domain/AgenRoleType.java
+++ b/src/main/java/eu/dissco/core/translator/domain/AgenRoleType.java
@@ -6,7 +6,8 @@ public enum AgenRoleType {
   DATA_TRANSLATOR("data-translator"),
   CREATOR("creator"),
   IDENTIFIER("identifier"),
-  GEOREFERENCER("georeferencer");
+  GEOREFERENCER("georeferencer"),
+  RIGHTS_OWNER("rights-owner");
 
   private final String name;
 

--- a/src/main/java/eu/dissco/core/translator/domain/AgentRoleType.java
+++ b/src/main/java/eu/dissco/core/translator/domain/AgentRoleType.java
@@ -1,6 +1,9 @@
 package eu.dissco.core.translator.domain;
 
-public enum AgenRoleType {
+import lombok.Getter;
+
+@Getter
+public enum AgentRoleType {
 
   COLLECTOR("collector"),
   DATA_TRANSLATOR("data-translator"),
@@ -11,11 +14,8 @@ public enum AgenRoleType {
 
   private final String name;
 
-  AgenRoleType(String name) {
+  AgentRoleType(String name) {
     this.name = name;
   }
 
-  public String getName() {
-    return name;
-  }
 }

--- a/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
@@ -16,7 +16,7 @@ import static eu.dissco.core.translator.domain.RelationshipType.HAS_SOURCE_SYSTE
 import static eu.dissco.core.translator.domain.RelationshipType.HAS_URL;
 import static eu.dissco.core.translator.schema.Agent.Type.SCHEMA_PERSON;
 import static eu.dissco.core.translator.schema.Agent.Type.SCHEMA_SOFTWARE_APPLICATION;
-import static eu.dissco.core.translator.terms.utils.AgentsUtils.setAgent;
+import static eu.dissco.core.translator.terms.utils.AgentsUtils.addAgent;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -294,9 +294,9 @@ public abstract class BaseDigitalObjectDirector {
         .withDctermsType(termMapper.retrieveTerm(new Type(), data, dwc))
         .withDctermsDate(termMapper.retrieveTerm(new Date(), data, dwc))
         .withDctermsTitle(termMapper.retrieveTerm(new Title(), data, dwc));
-    setAgent(citation.getOdsHasAgents(), termMapper.retrieveTerm(
+    citation.setOdsHasAgents(addAgent(citation.getOdsHasAgents(), termMapper.retrieveTerm(
         new eu.dissco.core.translator.terms.specimen.citation.Creator(),
-        data, dwc), null, CREATOR, SCHEMA_PERSON);
+        data, dwc), null, CREATOR, SCHEMA_PERSON));
     return citation;
   }
 
@@ -389,8 +389,8 @@ public abstract class BaseDigitalObjectDirector {
         .withDwcRelationshipOfResource(relationshipType.getName())
         .withDwcRelatedResourceID(relatedResource)
         .withDwcRelationshipEstablishedDate(java.util.Date.from(Instant.now()));
-    setAgent(entityRelationship.getOdsHasAgents(), fdoProperties.getApplicationName(),
-        fdoProperties.getApplicationPID(), DATA_TRANSLATOR, SCHEMA_SOFTWARE_APPLICATION);
+    entityRelationship.setOdsHasAgents(addAgent(entityRelationship.getOdsHasAgents(), fdoProperties.getApplicationName(),
+        fdoProperties.getApplicationPID(), DATA_TRANSLATOR, SCHEMA_SOFTWARE_APPLICATION));
     return entityRelationship;
   }
 
@@ -461,8 +461,8 @@ public abstract class BaseDigitalObjectDirector {
             termMapper.retrieveTerm(new VerbatimIdentification(), data, dwc))
         .withOdsHasTaxonIdentifications(List.of(mappedTaxonIdentification))
         .withOdsHasCitations(assembleIdentificationCitations(data, dwc));
-    setAgent(identification.getOdsHasAgents(), termMapper.retrieveTerm(new IdentifiedBy(), data, dwc),
-        termMapper.retrieveTerm(new IdentifiedByID(), data, dwc), IDENTIFIER, SCHEMA_PERSON);
+    identification.setOdsHasAgents(addAgent(identification.getOdsHasAgents(), termMapper.retrieveTerm(new IdentifiedBy(), data, dwc),
+        termMapper.retrieveTerm(new IdentifiedByID(), data, dwc), IDENTIFIER, SCHEMA_PERSON));
     return identification;
   }
 
@@ -491,8 +491,8 @@ public abstract class BaseDigitalObjectDirector {
         .withDwcGeoreferenceRemarks(termMapper.retrieveTerm(new GeoreferenceRemarks(), data, dwc))
         .withDwcGeoreferenceSources(termMapper.retrieveTerm(new GeoreferenceSources(), data, dwc))
         .withDwcPointRadiusSpatialFit(parseToDouble(new PointRadiusSpatialFit(), data, dwc));
-    setAgent(geoReference.getOdsHasAgents(), termMapper.retrieveTerm(
-        new GeoreferencedBy(), data, dwc), null, GEOREFERENCER, SCHEMA_PERSON);
+    geoReference.setOdsHasAgents(addAgent(geoReference.getOdsHasAgents(), termMapper.retrieveTerm(
+        new GeoreferencedBy(), data, dwc), null, GEOREFERENCER, SCHEMA_PERSON));
     var geologicalContext = new GeologicalContext()
         .withType("ods:GeologicalContext")
         .withDwcLowestBiostratigraphicZone(
@@ -590,8 +590,8 @@ public abstract class BaseDigitalObjectDirector {
         .withDwcVitality(termMapper.retrieveTerm(new Vitality(), data, dwc))
         .withOdsHasLocation(location)
         .withOdsHasAssertions(assertions);
-    setAgent(event.getOdsHasAgents(), termMapper.retrieveTerm(new RecordedBy(), data, dwc),
-        termMapper.retrieveTerm(new RecordedByID(), data, dwc), COLLECTOR, SCHEMA_PERSON);
+    event.setOdsHasAgents(addAgent(event.getOdsHasAgents(), termMapper.retrieveTerm(new RecordedBy(), data, dwc),
+        termMapper.retrieveTerm(new RecordedByID(), data, dwc), COLLECTOR, SCHEMA_PERSON));
     return List.of(event);
   }
 
@@ -703,10 +703,10 @@ public abstract class BaseDigitalObjectDirector {
         .withDctermsDescription(termMapper.retrieveTerm(new Description(), mediaRecord, dwc))
         .withOdsHasIdentifiers(assembleIdentifiers(mediaRecord))
         .withOdsHasAssertions(new MediaAssertions().gatherAssertions(mediaRecord, dwc));
-    setAgent(digitalMedia.getOdsHasAgents(), termMapper
-        .retrieveTerm(new Creator(), mediaRecord, dwc), null, CREATOR, SCHEMA_PERSON);
-    setAgent(digitalMedia.getOdsHasAgents(), termMapper
-        .retrieveTerm(new RightsOwner(), mediaRecord, dwc), null, RIGHTS_OWNER, SCHEMA_PERSON);
+    digitalMedia.setOdsHasAgents(addAgent(digitalMedia.getOdsHasAgents(), termMapper
+        .retrieveTerm(new Creator(), mediaRecord, dwc), null, CREATOR, SCHEMA_PERSON));
+    digitalMedia.setOdsHasAgents(addAgent(digitalMedia.getOdsHasAgents(), termMapper
+        .retrieveTerm(new RightsOwner(), mediaRecord, dwc), null, RIGHTS_OWNER, SCHEMA_PERSON));
     digitalMedia.withOdsHasEntityRelationships(
         assembleDigitalMediaEntityRelationships(digitalMedia));
     return digitalMedia;

--- a/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
@@ -1,11 +1,11 @@
 package eu.dissco.core.translator.terms;
 
-import static eu.dissco.core.translator.domain.AgenRoleType.COLLECTOR;
-import static eu.dissco.core.translator.domain.AgenRoleType.CREATOR;
-import static eu.dissco.core.translator.domain.AgenRoleType.DATA_TRANSLATOR;
-import static eu.dissco.core.translator.domain.AgenRoleType.GEOREFERENCER;
-import static eu.dissco.core.translator.domain.AgenRoleType.IDENTIFIER;
-import static eu.dissco.core.translator.domain.AgenRoleType.RIGHTS_OWNER;
+import static eu.dissco.core.translator.domain.AgentRoleType.COLLECTOR;
+import static eu.dissco.core.translator.domain.AgentRoleType.CREATOR;
+import static eu.dissco.core.translator.domain.AgentRoleType.DATA_TRANSLATOR;
+import static eu.dissco.core.translator.domain.AgentRoleType.GEOREFERENCER;
+import static eu.dissco.core.translator.domain.AgentRoleType.IDENTIFIER;
+import static eu.dissco.core.translator.domain.AgentRoleType.RIGHTS_OWNER;
 import static eu.dissco.core.translator.domain.RelationshipType.HAS_FDO_TYPE;
 import static eu.dissco.core.translator.domain.RelationshipType.HAS_LICENSE;
 import static eu.dissco.core.translator.domain.RelationshipType.HAS_ORGANISATION_ID;

--- a/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
@@ -1,9 +1,11 @@
 package eu.dissco.core.translator.terms;
 
+import static eu.dissco.core.translator.domain.AgenRoleType.COLLECTOR;
 import static eu.dissco.core.translator.domain.AgenRoleType.CREATOR;
 import static eu.dissco.core.translator.domain.AgenRoleType.DATA_TRANSLATOR;
 import static eu.dissco.core.translator.domain.AgenRoleType.GEOREFERENCER;
 import static eu.dissco.core.translator.domain.AgenRoleType.IDENTIFIER;
+import static eu.dissco.core.translator.domain.AgenRoleType.RIGHTS_OWNER;
 import static eu.dissco.core.translator.domain.RelationshipType.HAS_FDO_TYPE;
 import static eu.dissco.core.translator.domain.RelationshipType.HAS_LICENSE;
 import static eu.dissco.core.translator.domain.RelationshipType.HAS_ORGANISATION_ID;
@@ -14,17 +16,16 @@ import static eu.dissco.core.translator.domain.RelationshipType.HAS_SOURCE_SYSTE
 import static eu.dissco.core.translator.domain.RelationshipType.HAS_URL;
 import static eu.dissco.core.translator.schema.Agent.Type.SCHEMA_PERSON;
 import static eu.dissco.core.translator.schema.Agent.Type.SCHEMA_SOFTWARE_APPLICATION;
+import static eu.dissco.core.translator.terms.utils.AgentsUtils.setAgent;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.translator.component.OrganisationNameComponent;
 import eu.dissco.core.translator.component.SourceSystemComponent;
-import eu.dissco.core.translator.domain.AgenRoleType;
 import eu.dissco.core.translator.domain.RelationshipType;
 import eu.dissco.core.translator.exception.OrganisationException;
 import eu.dissco.core.translator.exception.UnknownPhysicalSpecimenIdType;
 import eu.dissco.core.translator.properties.FdoProperties;
-import eu.dissco.core.translator.schema.Agent;
 import eu.dissco.core.translator.schema.Citation;
 import eu.dissco.core.translator.schema.DigitalMedia;
 import eu.dissco.core.translator.schema.DigitalMedia.DctermsType;
@@ -39,7 +40,6 @@ import eu.dissco.core.translator.schema.Georeference;
 import eu.dissco.core.translator.schema.Identification;
 import eu.dissco.core.translator.schema.Identifier;
 import eu.dissco.core.translator.schema.Location;
-import eu.dissco.core.translator.schema.OdsHasRole;
 import eu.dissco.core.translator.schema.TaxonIdentification;
 import eu.dissco.core.translator.terms.media.AccessURI;
 import eu.dissco.core.translator.terms.media.Available;
@@ -70,9 +70,11 @@ import eu.dissco.core.translator.terms.media.SubjectPartLiteral;
 import eu.dissco.core.translator.terms.media.Subtype;
 import eu.dissco.core.translator.terms.media.SubtypeLiteral;
 import eu.dissco.core.translator.terms.media.TimeOfDay;
+import eu.dissco.core.translator.terms.media.UsageTerms;
 import eu.dissco.core.translator.terms.media.Variant;
 import eu.dissco.core.translator.terms.media.VariantDescription;
 import eu.dissco.core.translator.terms.media.VariantLiteral;
+import eu.dissco.core.translator.terms.media.WebStatement;
 import eu.dissco.core.translator.terms.specimen.AccessRights;
 import eu.dissco.core.translator.terms.specimen.BasisOfRecord;
 import eu.dissco.core.translator.terms.specimen.CollectionID;
@@ -116,6 +118,7 @@ import eu.dissco.core.translator.terms.specimen.event.EventAssertions;
 import eu.dissco.core.translator.terms.specimen.event.EventDate;
 import eu.dissco.core.translator.terms.specimen.event.EventRemark;
 import eu.dissco.core.translator.terms.specimen.event.EventRemarks;
+import eu.dissco.core.translator.terms.specimen.event.EventType;
 import eu.dissco.core.translator.terms.specimen.event.FieldNotes;
 import eu.dissco.core.translator.terms.specimen.event.FieldNumber;
 import eu.dissco.core.translator.terms.specimen.event.GeoreferenceVerificationStatus;
@@ -138,6 +141,7 @@ import eu.dissco.core.translator.terms.specimen.identification.IdentificationID;
 import eu.dissco.core.translator.terms.specimen.identification.IdentificationRemarks;
 import eu.dissco.core.translator.terms.specimen.identification.IdentificationVerificationStatus;
 import eu.dissco.core.translator.terms.specimen.identification.IdentifiedBy;
+import eu.dissco.core.translator.terms.specimen.identification.IdentifiedByID;
 import eu.dissco.core.translator.terms.specimen.identification.TypeStatus;
 import eu.dissco.core.translator.terms.specimen.identification.VerbatimIdentification;
 import eu.dissco.core.translator.terms.specimen.identification.taxonomy.AcceptedNameUsage;
@@ -280,19 +284,20 @@ public abstract class BaseDigitalObjectDirector {
   protected abstract List<Identification> assembleIdentifications(JsonNode data, boolean dwc);
 
   protected Citation createCitation(JsonNode data, boolean dwc) {
-    return new Citation()
+    var citation = new Citation()
         .withId(termMapper.retrieveTerm(new ReferenceIRI(), data, dwc))
         .withType("ods:Citation")
         .withDctermsBibliographicCitation(
             termMapper.retrieveTerm(new BibliographicCitation(), data, dwc))
         .withDctermsDescription(termMapper.retrieveTerm(new CitationDescription(), data, dwc))
         .withDctermsIdentifier(termMapper.retrieveTerm(new ReferenceIRI(), data, dwc))
-        .withOdsHasAgents(getAgent(termMapper.retrieveTerm(
-            new eu.dissco.core.translator.terms.specimen.citation.Creator(),
-            data, dwc), null, CREATOR, SCHEMA_PERSON))
         .withDctermsType(termMapper.retrieveTerm(new Type(), data, dwc))
         .withDctermsDate(termMapper.retrieveTerm(new Date(), data, dwc))
         .withDctermsTitle(termMapper.retrieveTerm(new Title(), data, dwc));
+    setAgent(citation.getOdsHasAgents(), termMapper.retrieveTerm(
+        new eu.dissco.core.translator.terms.specimen.citation.Creator(),
+        data, dwc), null, CREATOR, SCHEMA_PERSON);
+    return citation;
   }
 
   private DigitalSpecimen assembleDigitalSpecimenTerms(JsonNode data, boolean dwc)
@@ -338,10 +343,7 @@ public abstract class BaseDigitalObjectDirector {
         .withDwcDisposition(termMapper.retrieveTerm(new Disposition(), data, dwc))
         .withDwcInformationWithheld(termMapper.retrieveTerm(new InformationWithheld(), data, dwc))
         .withDwcVerbatimLabel(termMapper.retrieveTerm(new VerbatimLabel(), data, dwc))
-        .withDwcDataGeneralizations(termMapper.retrieveTerm(new DataGeneralizations(), data, dwc))
-        .withOdsHasAgents(getAgent(termMapper.retrieveTerm(new RecordedBy(), data, dwc),
-            termMapper.retrieveTerm(new RecordedByID(), data, dwc), AgenRoleType.COLLECTOR,
-            SCHEMA_PERSON));
+        .withDwcDataGeneralizations(termMapper.retrieveTerm(new DataGeneralizations(), data, dwc));
   }
 
   private String getOrganisationName(String organisationId) throws OrganisationException {
@@ -382,14 +384,14 @@ public abstract class BaseDigitalObjectDirector {
 
   private EntityRelationship getEntityRelationship(RelationshipType relationshipType,
       String relatedResource) {
-    return new EntityRelationship()
+    var entityRelationship = new EntityRelationship()
         .withType("ods:EntityRelationship")
         .withDwcRelationshipOfResource(relationshipType.getName())
         .withDwcRelatedResourceID(relatedResource)
-        .withOdsHasAgents(
-            getAgent(fdoProperties.getApplicationName(), fdoProperties.getApplicationPID(),
-                DATA_TRANSLATOR, SCHEMA_SOFTWARE_APPLICATION))
         .withDwcRelationshipEstablishedDate(java.util.Date.from(Instant.now()));
+    setAgent(entityRelationship.getOdsHasAgents(), fdoProperties.getApplicationName(),
+        fdoProperties.getApplicationPID(), DATA_TRANSLATOR, SCHEMA_SOFTWARE_APPLICATION);
+    return entityRelationship;
   }
 
   private List<eu.dissco.core.translator.schema.Identifier> assembleIdentifiers(JsonNode data) {
@@ -445,7 +447,7 @@ public abstract class BaseDigitalObjectDirector {
         .withDwcSuperfamily(termMapper.retrieveTerm(new Superfamily(), data, dwc))
         .withDwcTribe(termMapper.retrieveTerm(new Tribe(), data, dwc));
     var identificationId = termMapper.retrieveTerm(new IdentificationID(), data, dwc);
-    return new Identification()
+    var identification = new Identification()
         .withId(identificationId)
         .withType("ods:Identification")
         .withDwcIdentificationID(identificationId)
@@ -457,11 +459,11 @@ public abstract class BaseDigitalObjectDirector {
             termMapper.retrieveTerm(new IdentificationRemarks(), data, dwc))
         .withDwcVerbatimIdentification(
             termMapper.retrieveTerm(new VerbatimIdentification(), data, dwc))
-        .withOdsHasAgents(
-            getAgent(termMapper.retrieveTerm(new IdentifiedBy(), data, dwc), null, IDENTIFIER,
-                SCHEMA_PERSON))
         .withOdsHasTaxonIdentifications(List.of(mappedTaxonIdentification))
         .withOdsHasCitations(assembleIdentificationCitations(data, dwc));
+    setAgent(identification.getOdsHasAgents(), termMapper.retrieveTerm(new IdentifiedBy(), data, dwc),
+        termMapper.retrieveTerm(new IdentifiedByID(), data, dwc), IDENTIFIER, SCHEMA_PERSON);
+    return identification;
   }
 
 
@@ -488,10 +490,9 @@ public abstract class BaseDigitalObjectDirector {
         .withDwcGeoreferencedDate(termMapper.retrieveTerm(new GeoreferencedDate(), data, dwc))
         .withDwcGeoreferenceRemarks(termMapper.retrieveTerm(new GeoreferenceRemarks(), data, dwc))
         .withDwcGeoreferenceSources(termMapper.retrieveTerm(new GeoreferenceSources(), data, dwc))
-        .withDwcPointRadiusSpatialFit(parseToDouble(new PointRadiusSpatialFit(), data, dwc))
-        .withOdsHasAgents(
-            getAgent(termMapper.retrieveTerm(new GeoreferencedBy(), data, dwc), null,
-                GEOREFERENCER, SCHEMA_PERSON));
+        .withDwcPointRadiusSpatialFit(parseToDouble(new PointRadiusSpatialFit(), data, dwc));
+    setAgent(geoReference.getOdsHasAgents(), termMapper.retrieveTerm(
+        new GeoreferencedBy(), data, dwc), null, GEOREFERENCER, SCHEMA_PERSON);
     var geologicalContext = new GeologicalContext()
         .withType("ods:GeologicalContext")
         .withDwcLowestBiostratigraphicZone(
@@ -559,6 +560,7 @@ public abstract class BaseDigitalObjectDirector {
     var assertions = new EventAssertions().gatherEventAssertions(mapper, data, dwc);
     var event = new Event()
         .withType("ods:Event")
+        .withDwcEventType(termMapper.retrieveTerm(new EventType(), data, dwc))
         .withDwcFieldNumber(termMapper.retrieveTerm(new FieldNumber(), data, dwc))
         .withDwcEventDate(termMapper.retrieveTerm(new EventDate(), data, dwc))
         .withDwcVerbatimEventDate(termMapper.retrieveTerm(new VerbatimEventDate(), data, dwc))
@@ -588,6 +590,8 @@ public abstract class BaseDigitalObjectDirector {
         .withDwcVitality(termMapper.retrieveTerm(new Vitality(), data, dwc))
         .withOdsHasLocation(location)
         .withOdsHasAssertions(assertions);
+    setAgent(event.getOdsHasAgents(), termMapper.retrieveTerm(new RecordedBy(), data, dwc),
+        termMapper.retrieveTerm(new RecordedByID(), data, dwc), COLLECTOR, SCHEMA_PERSON);
     return List.of(event);
   }
 
@@ -653,6 +657,8 @@ public abstract class BaseDigitalObjectDirector {
         .withOdsOrganisationName(getOrganisationName(organisationId))
         .withAcAccessURI(termMapper.retrieveTerm(new AccessURI(), mediaRecord, dwc))
         .withDctermsRights(termMapper.retrieveTerm(new License(), mediaRecord, dwc))
+        .withXmpRightsUsageTerms(termMapper.retrieveTerm(new UsageTerms(), mediaRecord, dwc))
+        .withXmpRightsWebStatement(termMapper.retrieveTerm(new WebStatement(), mediaRecord, dwc))
         .withDctermsFormat(termMapper.retrieveTerm(new Format(), mediaRecord, dwc))
         .withDctermsType(retrieveEnum(new MediaType(), mediaRecord, dwc, DctermsType.class))
         .withDctermsSource(termMapper.retrieveTerm(new Source(), mediaRecord, dwc))
@@ -696,31 +702,14 @@ public abstract class BaseDigitalObjectDirector {
             termMapper.retrieveTerm(new Modified(), mediaRecord, dwc))
         .withDctermsDescription(termMapper.retrieveTerm(new Description(), mediaRecord, dwc))
         .withOdsHasIdentifiers(assembleIdentifiers(mediaRecord))
-        .withOdsHasAssertions(new MediaAssertions().gatherAssertions(mediaRecord, dwc))
-        .withOdsHasAgents(getAgent(termMapper.retrieveTerm(new Creator(), mediaRecord, dwc),
-            null, AgenRoleType.CREATOR, SCHEMA_PERSON));
+        .withOdsHasAssertions(new MediaAssertions().gatherAssertions(mediaRecord, dwc));
+    setAgent(digitalMedia.getOdsHasAgents(), termMapper
+        .retrieveTerm(new Creator(), mediaRecord, dwc), null, CREATOR, SCHEMA_PERSON);
+    setAgent(digitalMedia.getOdsHasAgents(), termMapper
+        .retrieveTerm(new RightsOwner(), mediaRecord, dwc), null, RIGHTS_OWNER, SCHEMA_PERSON);
     digitalMedia.withOdsHasEntityRelationships(
         assembleDigitalMediaEntityRelationships(digitalMedia));
     return digitalMedia;
-  }
-
-  private List<Agent> getAgent(String name, String id, AgenRoleType role, Agent.Type type) {
-    if (name != null || id != null) {
-      var agent = new Agent()
-          .withId(id)
-          .withType(type)
-          .withSchemaName(name)
-          .withSchemaIdentifier(id)
-          .withOdsHasRoles(
-              List.of(new OdsHasRole().withType("schema:Role").withSchemaRoleName(role.getName())));
-      if (id != null) {
-        agent.withOdsHasIdentifiers(List.of(
-            new Identifier().withId(id).withType("ods:Identifier").withDctermsIdentifier(id)));
-
-      }
-      return List.of(agent);
-    }
-    return null;
   }
 
   private List<EntityRelationship> assembleDigitalMediaEntityRelationships(

--- a/src/main/java/eu/dissco/core/translator/terms/media/UsageTerms.java
+++ b/src/main/java/eu/dissco/core/translator/terms/media/UsageTerms.java
@@ -3,10 +3,12 @@ package eu.dissco.core.translator.terms.media;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 
-public class WebStatement extends Term {
+@Slf4j
+public class UsageTerms extends Term {
 
-  public static final String TERM = "xmpRights:WebStatement";
+  public static final String TERM = "xmpRights:UsageTerms";
   private final List<String> dwcaTerms = List.of(TERM);
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/event/EventType.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/event/EventType.java
@@ -14,7 +14,7 @@ public class EventType extends Term {
   public String retrieveFromDWCA(JsonNode unit) {
     var eventType = super.searchJsonForTerm(unit, dwcaTerms);
     if (eventType == null) {
-      eventType = "Collecting";
+      eventType = "Collecting Event";
     }
     return eventType;
   }

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/event/EventType.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/event/EventType.java
@@ -1,0 +1,26 @@
+package eu.dissco.core.translator.terms.specimen.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class EventType extends Term {
+
+  public static final String TERM = DWC_PREFIX + "eventType";
+
+  private final List<String> dwcaTerms = List.of(TERM, VerbatimEventDate.TERM);
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    var eventType = super.searchJsonForTerm(unit, dwcaTerms);
+    if (eventType == null) {
+      eventType = "Collecting";
+    }
+    return eventType;
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/event/EventType.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/event/EventType.java
@@ -8,7 +8,7 @@ public class EventType extends Term {
 
   public static final String TERM = DWC_PREFIX + "eventType";
 
-  private final List<String> dwcaTerms = List.of(TERM, VerbatimEventDate.TERM);
+  private final List<String> dwcaTerms = List.of(TERM);
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/identification/IdentifiedByID.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/identification/IdentifiedByID.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class IdentifiedByID extends Term {
 
-  public static final String TERM = DWC_PREFIX + "identifiedById";
+  public static final String TERM = DWC_PREFIX + "identifiedByID";
 
   private final List<String> dwcaTerms = List.of(TERM);
 

--- a/src/main/java/eu/dissco/core/translator/terms/utils/AgentsUtils.java
+++ b/src/main/java/eu/dissco/core/translator/terms/utils/AgentsUtils.java
@@ -1,0 +1,84 @@
+package eu.dissco.core.translator.terms.utils;
+
+import eu.dissco.core.translator.domain.AgenRoleType;
+import eu.dissco.core.translator.schema.Agent.Type;
+import eu.dissco.core.translator.schema.Agent;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class AgentsUtils {
+
+  public static void setAgent(List<Agent> currentAgents, String termValue, String id,
+      AgenRoleType role, eu.dissco.core.translator.schema.Agent.Type type) {
+    if (currentAgents == null){
+      currentAgents = new ArrayList<>();
+    }
+    if (termValue != null || id != null) {
+      if ((termValue != null && (termValue.contains("&") || termValue.contains("|"))) || (
+          id != null && (id.contains("&") || id.contains("|")))) {
+        handleMultipleAgents(currentAgents, termValue, id, role, type);
+      } else {
+        String name = termValue;
+        if (termValue != null && termValue.contains("http") && id == null) {
+          id = termValue;
+          name = null;
+        } else if (termValue != null && termValue.contains("http") && id != null
+            && !id.equals(termValue)) {
+          log.warn(
+              "The id and term value do not match for term: {} and id: {}. Adding value as name and id as identifier",
+              termValue, id);
+        }
+        var agent = new Agent()
+            .withId(id)
+            .withType(type)
+            .withSchemaName(name)
+            .withSchemaIdentifier(id)
+            .withOdsHasRoles(
+                List.of(new eu.dissco.core.translator.schema.OdsHasRole().withType("schema:Role")
+                    .withSchemaRoleName(role.getName())));
+        if (id != null) {
+          agent.withOdsHasIdentifiers(List.of(
+              new eu.dissco.core.translator.schema.Identifier().withId(id)
+                  .withType("ods:Identifier")
+                  .withDctermsIdentifier(id)));
+        }
+        currentAgents.add(agent);
+      }
+    }
+  }
+
+  private static void handleMultipleAgents(
+      List<Agent> currentAgents, String termValue, String id, AgenRoleType role,
+      eu.dissco.core.translator.schema.Agent.Type type) {
+    var ids = new String[0];
+    var agents = new String[0];
+    if (termValue != null && (termValue.contains("&") || termValue.contains("|"))) {
+      agents = Arrays.stream(termValue.split("[&|]")).map(String::trim).toArray(String[]::new);
+    }
+    if (id != null && (id.contains("&") || id.contains("|"))) {
+      ids = Arrays.stream(id.split("[&|]")).map(String::trim).toArray(String[]::new);
+    }
+    if (agents.length == ids.length) {
+      for (int i = 0; i < agents.length; i++) {
+        setAgent(currentAgents, agents[i], ids[i], role, type);
+      }
+    } else if (agents.length > ids.length) {
+      log.warn(
+          "The number of agents values is greater than ids, ignoring ids for term: {} and id: {}",
+          termValue, id);
+      for (String agent : agents) {
+        setAgent(currentAgents, agent, null, role, type);
+      }
+    } else {
+      log.warn(
+          "The number of ids is greater than agent values, ignoring agent values for term: {} and id: {}",
+          termValue, id);
+      for (String idValue : ids) {
+        setAgent(currentAgents, null, idValue, role, type);
+      }
+    }
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/utils/AgentsUtils.java
+++ b/src/main/java/eu/dissco/core/translator/terms/utils/AgentsUtils.java
@@ -15,7 +15,7 @@ public class AgentsUtils {
     // This is a Utility class
   }
 
-  public static List<Agent> setAgent(List<Agent> currentAgents, String agentValue, String agentId,
+  public static List<Agent> addAgent(List<Agent> currentAgents, String agentValue, String agentId,
       AgentRoleType role, Type type) {
     var agents = new ArrayList<Agent>();
     if (currentAgents != null) {

--- a/src/main/java/eu/dissco/core/translator/terms/utils/AgentsUtils.java
+++ b/src/main/java/eu/dissco/core/translator/terms/utils/AgentsUtils.java
@@ -11,6 +11,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AgentsUtils {
 
+  private AgentsUtils() {
+    // This is a Utility class
+  }
+
   public static void setAgent(List<Agent> currentAgents, String termValue, String id,
       AgenRoleType role, eu.dissco.core.translator.schema.Agent.Type type) {
     if (currentAgents == null){
@@ -21,33 +25,38 @@ public class AgentsUtils {
           id != null && (id.contains("&") || id.contains("|")))) {
         handleMultipleAgents(currentAgents, termValue, id, role, type);
       } else {
-        String name = termValue;
-        if (termValue != null && termValue.contains("http") && id == null) {
-          id = termValue;
-          name = null;
-        } else if (termValue != null && termValue.contains("http") && id != null
-            && !id.equals(termValue)) {
-          log.warn(
-              "The id and term value do not match for term: {} and id: {}. Adding value as name and id as identifier",
-              termValue, id);
-        }
-        var agent = new Agent()
-            .withId(id)
-            .withType(type)
-            .withSchemaName(name)
-            .withSchemaIdentifier(id)
-            .withOdsHasRoles(
-                List.of(new eu.dissco.core.translator.schema.OdsHasRole().withType("schema:Role")
-                    .withSchemaRoleName(role.getName())));
-        if (id != null) {
-          agent.withOdsHasIdentifiers(List.of(
-              new eu.dissco.core.translator.schema.Identifier().withId(id)
-                  .withType("ods:Identifier")
-                  .withDctermsIdentifier(id)));
-        }
-        currentAgents.add(agent);
+        constructAgent(currentAgents, termValue, id, role, type);
       }
     }
+  }
+
+  private static void constructAgent(List<Agent> currentAgents, String termValue, String id,
+      AgenRoleType role, Type type) {
+    String name = termValue;
+    if (termValue != null && termValue.contains("http") && id == null) {
+      id = termValue;
+      name = null;
+    } else if (termValue != null && termValue.contains("http") && id != null
+        && !id.equals(termValue)) {
+      log.warn(
+          "The id and term value do not match for term: {} and id: {}. Adding value as name and id as identifier",
+          termValue, id);
+    }
+    var agent = new Agent()
+        .withId(id)
+        .withType(type)
+        .withSchemaName(name)
+        .withSchemaIdentifier(id)
+        .withOdsHasRoles(
+            List.of(new eu.dissco.core.translator.schema.OdsHasRole().withType("schema:Role")
+                .withSchemaRoleName(role.getName())));
+    if (id != null) {
+      agent.withOdsHasIdentifiers(List.of(
+          new eu.dissco.core.translator.schema.Identifier().withId(id)
+              .withType("ods:Identifier")
+              .withDctermsIdentifier(id)));
+    }
+    currentAgents.add(agent);
   }
 
   private static void handleMultipleAgents(

--- a/src/main/java/eu/dissco/core/translator/terms/utils/AgentsUtils.java
+++ b/src/main/java/eu/dissco/core/translator/terms/utils/AgentsUtils.java
@@ -1,8 +1,8 @@
 package eu.dissco.core.translator.terms.utils;
 
-import eu.dissco.core.translator.domain.AgenRoleType;
-import eu.dissco.core.translator.schema.Agent.Type;
+import eu.dissco.core.translator.domain.AgentRoleType;
 import eu.dissco.core.translator.schema.Agent;
+import eu.dissco.core.translator.schema.Agent.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -15,78 +15,79 @@ public class AgentsUtils {
     // This is a Utility class
   }
 
-  public static void setAgent(List<Agent> currentAgents, String termValue, String id,
-      AgenRoleType role, eu.dissco.core.translator.schema.Agent.Type type) {
-    if (currentAgents == null){
-      currentAgents = new ArrayList<>();
+  public static List<Agent> setAgent(List<Agent> currentAgents, String agentValue, String agentId,
+      AgentRoleType role, Type type) {
+    var agents = new ArrayList<Agent>();
+    if (currentAgents != null) {
+      agents.addAll(currentAgents);
     }
-    if (termValue != null || id != null) {
-      if ((termValue != null && (termValue.contains("&") || termValue.contains("|"))) || (
-          id != null && (id.contains("&") || id.contains("|")))) {
-        handleMultipleAgents(currentAgents, termValue, id, role, type);
+    if (agentValue != null || agentId != null) {
+      if ((agentValue != null && (agentValue.contains("&") || agentValue.contains("|"))) || (
+          agentId != null && (agentId.contains("&") || agentId.contains("|")))) {
+        handleMultipleAgents(agents, agentValue, agentId, role, type);
       } else {
-        constructAgent(currentAgents, termValue, id, role, type);
+        constructAgent(agents, agentValue, agentId, role, type);
       }
     }
+    return agents;
   }
 
-  private static void constructAgent(List<Agent> currentAgents, String termValue, String id,
-      AgenRoleType role, Type type) {
-    String name = termValue;
-    if (termValue != null && termValue.contains("http") && id == null) {
-      id = termValue;
-      name = null;
-    } else if (termValue != null && termValue.contains("http") && id != null
-        && !id.equals(termValue)) {
+  private static void constructAgent(List<Agent> agents, String agentValue, String agentId,
+      AgentRoleType role, Type type) {
+    String agentName = agentValue;
+    if (agentValue != null && agentValue.contains("http") && agentId == null) {
+      agentId = agentValue;
+      agentName = null;
+    } else if (agentValue != null && agentValue.contains("http") && agentId != null
+        && !agentId.equals(agentValue)) {
       log.warn(
-          "The id and term value do not match for term: {} and id: {}. Adding value as name and id as identifier",
-          termValue, id);
+          "The agentId and agentValue do not match for term: {} and agentId: {}. Adding value as agentName and agentId as identifier",
+          agentValue, agentId);
     }
     var agent = new Agent()
-        .withId(id)
+        .withId(agentId)
         .withType(type)
-        .withSchemaName(name)
-        .withSchemaIdentifier(id)
+        .withSchemaName(agentName)
+        .withSchemaIdentifier(agentId)
         .withOdsHasRoles(
             List.of(new eu.dissco.core.translator.schema.OdsHasRole().withType("schema:Role")
                 .withSchemaRoleName(role.getName())));
-    if (id != null) {
+    if (agentId != null) {
       agent.withOdsHasIdentifiers(List.of(
-          new eu.dissco.core.translator.schema.Identifier().withId(id)
+          new eu.dissco.core.translator.schema.Identifier().withId(agentId)
               .withType("ods:Identifier")
-              .withDctermsIdentifier(id)));
+              .withDctermsIdentifier(agentId)));
     }
-    currentAgents.add(agent);
+    agents.add(agent);
   }
 
   private static void handleMultipleAgents(
-      List<Agent> currentAgents, String termValue, String id, AgenRoleType role,
-      eu.dissco.core.translator.schema.Agent.Type type) {
+      List<Agent> agents, String agentValue, String agentId, AgentRoleType role, Type type) {
     var ids = new String[0];
-    var agents = new String[0];
-    if (termValue != null && (termValue.contains("&") || termValue.contains("|"))) {
-      agents = Arrays.stream(termValue.split("[&|]")).map(String::trim).toArray(String[]::new);
+    var agentValues = new String[0];
+    if (agentValue != null && (agentValue.contains("&") || agentValue.contains("|"))) {
+      agentValues = Arrays.stream(agentValue.split("[&|]")).map(String::trim).toArray(String[]::new);
     }
-    if (id != null && (id.contains("&") || id.contains("|"))) {
-      ids = Arrays.stream(id.split("[&|]")).map(String::trim).toArray(String[]::new);
+    if (agentId != null && (agentId.contains("&") || agentId.contains("|"))) {
+      ids = Arrays.stream(agentId.split("[&|]")).map(String::trim).toArray(String[]::new);
     }
-    if (agents.length == ids.length) {
-      for (int i = 0; i < agents.length; i++) {
-        setAgent(currentAgents, agents[i], ids[i], role, type);
+    if (agentValues.length == ids.length) {
+      for (int i = 0; i < agentValues.length; i++) {
+        constructAgent(agents, agentValues[i], ids[i], role, type);
       }
-    } else if (agents.length > ids.length) {
+    } else if (agentValues.length > ids.length) {
       log.warn(
-          "The number of agents values is greater than ids, ignoring ids for term: {} and id: {}",
-          termValue, id);
-      for (String agent : agents) {
-        setAgent(currentAgents, agent, null, role, type);
+          "The number of agentValues values is greater than ids, ignoring ids for term: {} and agentId: {}",
+          agentValue, agentId);
+      for (String agent : agentValues) {
+        constructAgent(agents, agent, null, role, type);
       }
     } else {
       log.warn(
-          "The number of ids is greater than agent values, ignoring agent values for term: {} and id: {}",
-          termValue, id);
+          "The number of ids is greater than agentValue, ignoring agentValue values for term: {} and agentId: {}",
+          agentValue, agentId);
       for (String idValue : ids) {
-        setAgent(currentAgents, null, idValue, role, type);
+        constructAgent(agents, null, idValue, role, type);
       }
     }
   }

--- a/src/main/resources/json-schema/digital-media.json
+++ b/src/main/resources/json-schema/digital-media.json
@@ -211,6 +211,22 @@
         "https://creativecommons.org/licenses/by-nc-sa/4.0/"
       ]
     },
+    "xmpRights:UsageTerms": {
+      "type": "string",
+      "description": "A collection of text instructions on how a resource can be legally used, given in a variety of languages",
+      "examples": [
+        "CC BY 4.0",
+        "CC BY-NC-SA 4.0"
+      ]
+    },
+    "xmpRights:WebStatement": {
+      "type": "string",
+      "description": "A Web URL for a statement of the ownership and usage rights for this resource",
+      "examples": [
+        "https://creativecommons.org/licenses/by/4.0/",
+        "https://creativecommons.org/licenses/by-nc-sa/4.0/"
+      ]
+    },
     "xmpRights:Owner": {
       "type": "string",
       "description": "A list of legal owners of the resource",

--- a/src/main/resources/json-schema/digital-specimen.json
+++ b/src/main/resources/json-schema/digital-specimen.json
@@ -451,7 +451,7 @@
     },
     "ods:hasAgents": {
       "type": "array",
-      "description": "Contains all agents that have are connected to the specimen",
+      "description": "Contains all agents that are connected to the specimen. Agents that are part of a specific part of the specimen should be added there. For example a Collector is connected to the CollectingEvent so is add in the event",
       "items": {
         "type": "object",
         "$ref": "https://schemas.dissco.tech/schemas/fdo-type/shared-model/0.4.0/agent.json"

--- a/src/test/java/eu/dissco/core/translator/terms/media/UsageTermsTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/media/UsageTermsTest.java
@@ -8,32 +8,32 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class WebStatementTest {
+class UsageTermsTest {
 
-  private final WebStatement webStatement = new WebStatement();
+  private final UsageTerms usageTerms = new UsageTerms();
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
-    var webStatementString = "https://creativecommons.org/licenses/by/4.0/";
+    var usageTermsString = "CC BY-NC-SA 4.0";
     var unit = MAPPER.createObjectNode();
-    unit.put("xmpRights:WebStatement", webStatementString);
+    unit.put("xmpRights:UsageTerms", usageTermsString);
 
     // When
-    var result = webStatement.retrieveFromDWCA(unit);
+    var result = usageTerms.retrieveFromDWCA(unit);
 
     // Then
-    assertThat(result).isEqualTo(webStatementString);
+    assertThat(result).isEqualTo(usageTermsString);
   }
 
 
   @Test
   void testGetTerm() {
     // When
-    var result = webStatement.getTerm();
+    var result = usageTerms.getTerm();
 
     // Then
-    assertThat(result).isEqualTo(WebStatement.TERM);
+    assertThat(result).isEqualTo(UsageTerms.TERM);
   }
 
 }

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/event/EventTypeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/event/EventTypeTest.java
@@ -34,7 +34,7 @@ class EventTypeTest {
     var result = eventType.retrieveFromDWCA(unit);
 
     // Then
-    assertThat(result).isEqualTo("Collecting");
+    assertThat(result).isEqualTo("Collecting Event");
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/event/EventTypeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/event/EventTypeTest.java
@@ -1,0 +1,49 @@
+package eu.dissco.core.translator.terms.specimen.event;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EventTypeTest {
+
+  private final EventType eventType = new EventType();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("dwc:eventType", "Sampling");
+
+    // When
+    var result = eventType.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo("Sampling");
+  }
+
+  @Test
+  void testRetrieveFromDWCANoValue() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+
+    // When
+    var result = eventType.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo("Collecting");
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = eventType.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(EventType.TERM);
+  }
+
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/identification/IdentifiedByIDTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/identification/IdentifiedByIDTest.java
@@ -17,7 +17,7 @@ class IdentifiedByIDTest {
     // Given
     var identifiedByString = "https://orcid.org/0000-0002-5669-2769";
     var unit = MAPPER.createObjectNode();
-    unit.put("dwc:identifiedById", identifiedByString);
+    unit.put("dwc:identifiedByID", identifiedByString);
 
     // When
     var result = identifiedById.retrieveFromDWCA(unit);

--- a/src/test/java/eu/dissco/core/translator/terms/utils/AgentUtilsTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/utils/AgentUtilsTest.java
@@ -1,13 +1,13 @@
 package eu.dissco.core.translator.terms.utils;
 
-import static eu.dissco.core.translator.domain.AgenRoleType.CREATOR;
+import static eu.dissco.core.translator.domain.AgentRoleType.CREATOR;
 import static eu.dissco.core.translator.schema.Agent.Type.SCHEMA_PERSON;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import eu.dissco.core.translator.schema.Agent;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -80,15 +80,28 @@ class AgentUtilsTest {
 
   @ParameterizedTest
   @MethodSource("agentProvider")
-  void testSimpleAgent(String termValue, String id, List<Agent> expected) {
-    // Given
-    var result = new ArrayList<Agent>();
+  void testSetAgent(String termValue, String id, List<Agent> expected) {
 
     // When
-    AgentsUtils.setAgent(result, termValue, id, CREATOR, SCHEMA_PERSON);
+    var result = AgentsUtils.setAgent(null, termValue, id, CREATOR, SCHEMA_PERSON);
 
     // Then
     assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void testSetAgentUnmutableLiat() {
+    // Given
+    var agentOne = createAgent("Tom Dijkema", "https://orcid.org/0000-0001-9790-9277");
+    var agentTwo = createAgent("Fricke, Ronald", "http://orcid.org/0000-0002-9079-593X");
+
+    // When
+    var result = AgentsUtils.setAgent(
+        List.of(agentOne),
+        "Fricke, Ronald", "http://orcid.org/0000-0002-9079-593X", CREATOR, SCHEMA_PERSON);
+
+    // Then
+    assertThat(result).isEqualTo(List.of(agentOne, agentTwo));
   }
 
 }

--- a/src/test/java/eu/dissco/core/translator/terms/utils/AgentUtilsTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/utils/AgentUtilsTest.java
@@ -1,0 +1,94 @@
+package eu.dissco.core.translator.terms.utils;
+
+import static eu.dissco.core.translator.domain.AgenRoleType.CREATOR;
+import static eu.dissco.core.translator.schema.Agent.Type.SCHEMA_PERSON;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import eu.dissco.core.translator.schema.Agent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgentUtilsTest {
+
+  public static Stream<Arguments> agentProvider() {
+    return Stream.of(
+        Arguments.of(null, null, List.of()
+        ),
+        Arguments.of("Fricke, Ronald", "http://orcid.org/0000-0002-9079-593X",
+            List.of(createAgent("Fricke, Ronald", "http://orcid.org/0000-0002-9079-593X"))
+        ),
+        Arguments.of("Fricke, Ronald", null,
+            List.of(createAgent("Fricke, Ronald", null))
+        ),
+        Arguments.of("http://orcid.org/0000-0002-9079-593X", null,
+            List.of(createAgent(null, "http://orcid.org/0000-0002-9079-593X"))
+        ),
+        Arguments.of("http://orcid.org/0000-0002-9079-593X",
+            "https://orcid.org/0000-0001-9790-9277",
+            List.of(createAgent("http://orcid.org/0000-0002-9079-593X",
+                "https://orcid.org/0000-0001-9790-9277"))
+        ),
+        Arguments.of("  Fricke, Ronald  | Tom Dijkema  ",
+            "http://orcid.org/0000-0002-9079-593X |  https://orcid.org/0000-0001-9790-9277  ",
+            List.of(
+                createAgent("Fricke, Ronald", "http://orcid.org/0000-0002-9079-593X"),
+                createAgent("Tom Dijkema", "https://orcid.org/0000-0001-9790-9277"))
+        ),
+        Arguments.of("  Fricke, Ronald  & https://orcid.org/0000-0001-9790-9277  ", null,
+            List.of(
+                createAgent("Fricke, Ronald", null),
+                createAgent(null, "https://orcid.org/0000-0001-9790-9277"))
+        ),
+        Arguments.of("Fricke, Ronald",
+            "http://orcid.org/0000-0002-9079-593X |  https://orcid.org/0000-0001-9790-9277",
+            List.of(
+                createAgent(null, "http://orcid.org/0000-0002-9079-593X"),
+                createAgent(null, "https://orcid.org/0000-0001-9790-9277"))
+        ),
+        Arguments.of("Fricke, Ronald & Tom Dijkema",
+            "https://orcid.org/0000-0001-9790-9277",
+            List.of(
+                createAgent("Fricke, Ronald", null),
+                createAgent("Tom Dijkema", null))
+        )
+    );
+  }
+
+  private static Agent createAgent(String name, String id) {
+    var agent = new Agent()
+        .withId(id)
+        .withType(SCHEMA_PERSON)
+        .withSchemaName(name)
+        .withSchemaIdentifier(id)
+        .withOdsHasRoles(
+            List.of(new eu.dissco.core.translator.schema.OdsHasRole().withType("schema:Role")
+                .withSchemaRoleName(CREATOR.getName())));
+    if (id != null) {
+      agent.withOdsHasIdentifiers(
+          List.of(new eu.dissco.core.translator.schema.Identifier().withType("ods:Identifier")
+              .withId(id).withDctermsIdentifier(id)));
+    }
+    return agent;
+  }
+
+  @ParameterizedTest
+  @MethodSource("agentProvider")
+  void testSimpleAgent(String termValue, String id, List<Agent> expected) {
+    // Given
+    var result = new ArrayList<Agent>();
+
+    // When
+    AgentsUtils.setAgent(result, termValue, id, CREATOR, SCHEMA_PERSON);
+
+    // Then
+    assertThat(result).isEqualTo(expected);
+  }
+
+}

--- a/src/test/java/eu/dissco/core/translator/terms/utils/AgentUtilsTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/utils/AgentUtilsTest.java
@@ -80,23 +80,23 @@ class AgentUtilsTest {
 
   @ParameterizedTest
   @MethodSource("agentProvider")
-  void testSetAgent(String termValue, String id, List<Agent> expected) {
+  void testAddAgent(String termValue, String id, List<Agent> expected) {
 
     // When
-    var result = AgentsUtils.setAgent(null, termValue, id, CREATOR, SCHEMA_PERSON);
+    var result = AgentsUtils.addAgent(null, termValue, id, CREATOR, SCHEMA_PERSON);
 
     // Then
     assertThat(result).isEqualTo(expected);
   }
 
   @Test
-  void testSetAgentUnmutableLiat() {
+  void testAddAgentUnmutableLiat() {
     // Given
     var agentOne = createAgent("Tom Dijkema", "https://orcid.org/0000-0001-9790-9277");
     var agentTwo = createAgent("Fricke, Ronald", "http://orcid.org/0000-0002-9079-593X");
 
     // When
-    var result = AgentsUtils.setAgent(
+    var result = AgentsUtils.addAgent(
         List.of(agentOne),
         "Fricke, Ronald", "http://orcid.org/0000-0002-9079-593X", CREATOR, SCHEMA_PERSON);
 


### PR DESCRIPTION
Improve creation of Agent object:
- If value is a resolvable identifier use it as identifier (comment on previous PR)
- When multiple agents in single field parse them to different agents 
  - When equal name and identifier combination assume order is the same
  - When unequal take the list with the most entries 

Set default EventType to "Collecting Event"
Set recorded by as Collector on the main event

Add two fields to media regarding license 