### PR TITLE
Add mapping for chronometricAge

### DIFF
--- a/src/main/java/eu/dissco/core/translator/domain/AgentRoleType.java
+++ b/src/main/java/eu/dissco/core/translator/domain/AgentRoleType.java
@@ -10,7 +10,8 @@ public enum AgentRoleType {
   CREATOR("creator"),
   IDENTIFIER("identifier"),
   GEOREFERENCER("georeferencer"),
-  RIGHTS_OWNER("rights-owner");
+  RIGHTS_OWNER("rights-owner"),
+  CHRONOMETRIC_AGE_DETERMINER("chronometric-age-determiner"),;
 
   private final String name;
 

--- a/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
@@ -1,5 +1,6 @@
 package eu.dissco.core.translator.terms;
 
+import static eu.dissco.core.translator.domain.AgentRoleType.CHRONOMETRIC_AGE_DETERMINER;
 import static eu.dissco.core.translator.domain.AgentRoleType.COLLECTOR;
 import static eu.dissco.core.translator.domain.AgentRoleType.CREATOR;
 import static eu.dissco.core.translator.domain.AgentRoleType.GEOREFERENCER;
@@ -24,6 +25,7 @@ import eu.dissco.core.translator.component.SourceSystemComponent;
 import eu.dissco.core.translator.exception.OrganisationException;
 import eu.dissco.core.translator.exception.UnknownPhysicalSpecimenIdType;
 import eu.dissco.core.translator.properties.FdoProperties;
+import eu.dissco.core.translator.schema.ChronometricAge;
 import eu.dissco.core.translator.schema.Citation;
 import eu.dissco.core.translator.schema.DigitalMedia;
 import eu.dissco.core.translator.schema.DigitalMedia.DctermsType;
@@ -101,6 +103,24 @@ import eu.dissco.core.translator.terms.specimen.TopicDiscipline;
 import eu.dissco.core.translator.terms.specimen.TopicDomain;
 import eu.dissco.core.translator.terms.specimen.TopicOrigin;
 import eu.dissco.core.translator.terms.specimen.VerbatimLabel;
+import eu.dissco.core.translator.terms.specimen.chronometric.ChronometricAgeConversionProtocol;
+import eu.dissco.core.translator.terms.specimen.chronometric.ChronometricAgeDeterminedBy;
+import eu.dissco.core.translator.terms.specimen.chronometric.ChronometricAgeDeterminedDate;
+import eu.dissco.core.translator.terms.specimen.chronometric.ChronometricAgeID;
+import eu.dissco.core.translator.terms.specimen.chronometric.ChronometricAgeProtocol;
+import eu.dissco.core.translator.terms.specimen.chronometric.ChronometricAgeReferences;
+import eu.dissco.core.translator.terms.specimen.chronometric.ChronometricAgeRemarks;
+import eu.dissco.core.translator.terms.specimen.chronometric.ChronometricAgeUncertaintyInYears;
+import eu.dissco.core.translator.terms.specimen.chronometric.ChronometricAgeUncertaintyMethod;
+import eu.dissco.core.translator.terms.specimen.chronometric.EarliestChronometricAge;
+import eu.dissco.core.translator.terms.specimen.chronometric.EarliestChronometricAgeReferenceSystem;
+import eu.dissco.core.translator.terms.specimen.chronometric.LatestChronometricAge;
+import eu.dissco.core.translator.terms.specimen.chronometric.LatestChronometricAgeReferenceSystem;
+import eu.dissco.core.translator.terms.specimen.chronometric.MaterialDated;
+import eu.dissco.core.translator.terms.specimen.chronometric.MaterialDatedID;
+import eu.dissco.core.translator.terms.specimen.chronometric.MaterialDatedRelationship;
+import eu.dissco.core.translator.terms.specimen.chronometric.UncalibratedChronometricAge;
+import eu.dissco.core.translator.terms.specimen.chronometric.VerbatimChronometricAge;
 import eu.dissco.core.translator.terms.specimen.citation.BibliographicCitation;
 import eu.dissco.core.translator.terms.specimen.citation.CitationDescription;
 import eu.dissco.core.translator.terms.specimen.citation.Date;
@@ -259,6 +279,7 @@ public abstract class BaseDigitalObjectDirector {
     ds.withOdsHasIdentifiers(assembleIdentifiers(data));
     ds.withOdsHasCitations(assembleSpecimenCitations(data, dwc));
     ds.withOdsHasEntityRelationships(assembleDigitalSpecimenEntityRelationships(ds));
+    ds.withOdsHasChronometricAges(assembleChronometricAges(data, dwc));
     setCalculatedFields(ds, data);
     return ds;
   }
@@ -279,6 +300,8 @@ public abstract class BaseDigitalObjectDirector {
   protected abstract List<Citation> assembleIdentificationCitations(JsonNode data, boolean dwc);
 
   protected abstract List<Identification> assembleIdentifications(JsonNode data, boolean dwc);
+
+  protected abstract List<ChronometricAge> assembleChronometricAges(JsonNode data, boolean dwc);
 
   protected Citation createCitation(JsonNode data, boolean dwc) {
     var citation = new Citation()
@@ -398,6 +421,45 @@ public abstract class BaseDigitalObjectDirector {
       }
     }
     return identifiers;
+  }
+
+  protected ChronometricAge createChronometricAge(JsonNode data, boolean dwc) {
+    var chronometricAge = new ChronometricAge()
+        .withChronoChronometricAgeConversionProtocol(
+            termMapper.retrieveTerm(new ChronometricAgeConversionProtocol(), data, dwc))
+        .withChronoChronometricAgeDeterminedDate(
+            termMapper.retrieveTerm(new ChronometricAgeDeterminedDate(), data, dwc))
+        .withChronoChronometricAgeID(termMapper.retrieveTerm(new ChronometricAgeID(), data, dwc))
+        .withChronoChronometricAgeReferences(
+            termMapper.retrieveTerm(new ChronometricAgeReferences(), data, dwc))
+        .withChronoChronometricAgeRemarks(
+            termMapper.retrieveTerm(new ChronometricAgeRemarks(), data, dwc))
+        .withChronoChronometricAgeUncertaintyInYears(
+            parseToInteger(new ChronometricAgeUncertaintyInYears(), data, dwc))
+        .withChronoChronometricAgeUncertaintyMethod(
+            termMapper.retrieveTerm(new ChronometricAgeUncertaintyMethod(), data, dwc))
+        .withChronoEarliestChronometricAge(parseToInteger(new EarliestChronometricAge(), data, dwc))
+        .withChronoEarliestChronometricAgeReferenceSystem(
+            termMapper.retrieveTerm(new EarliestChronometricAgeReferenceSystem(), data, dwc))
+        .withChronoLatestChronometricAge(parseToInteger(new LatestChronometricAge(), data, dwc))
+        .withChronoLatestChronometricAgeReferenceSystem(
+            termMapper.retrieveTerm(new LatestChronometricAgeReferenceSystem(), data, dwc))
+        .withChronoMaterialDated(termMapper.retrieveTerm(new MaterialDated(), data, dwc))
+        .withChronoMaterialDatedID(termMapper.retrieveTerm(new MaterialDatedID(), data, dwc))
+        .withChronoMaterialDatedRelationship(
+            termMapper.retrieveTerm(new MaterialDatedRelationship(), data, dwc))
+        .withChronoUncalibratedChronometricAge(
+            termMapper.retrieveTerm(new UncalibratedChronometricAge(), data, dwc))
+        .withChronoVerbatimChronometricAge(
+            termMapper.retrieveTerm(new VerbatimChronometricAge(), data, dwc))
+        .withChronoChronometricAgeProtocol(
+            termMapper.retrieveTerm(new ChronometricAgeProtocol(), data, dwc))
+        .withChronoVerbatimChronometricAge(
+            termMapper.retrieveTerm(new VerbatimChronometricAge(), data, dwc));
+    chronometricAge.setOdsHasAgents(addAgent(chronometricAge.getOdsHasAgents(),
+        termMapper.retrieveTerm(new ChronometricAgeDeterminedBy(), data, dwc), null,
+        CHRONOMETRIC_AGE_DETERMINER, SCHEMA_PERSON));
+    return chronometricAge;
   }
 
   protected Identification createIdentification(JsonNode data, boolean dwc) {

--- a/src/main/java/eu/dissco/core/translator/terms/BiocaseDigitalObjectDirector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/BiocaseDigitalObjectDirector.java
@@ -6,6 +6,7 @@ import eu.dissco.core.translator.Profiles;
 import eu.dissco.core.translator.component.OrganisationNameComponent;
 import eu.dissco.core.translator.component.SourceSystemComponent;
 import eu.dissco.core.translator.properties.FdoProperties;
+import eu.dissco.core.translator.schema.ChronometricAge;
 import eu.dissco.core.translator.schema.Citation;
 import eu.dissco.core.translator.schema.DigitalSpecimen;
 import eu.dissco.core.translator.schema.Identification;
@@ -80,6 +81,24 @@ public class BiocaseDigitalObjectDirector extends BaseDigitalObjectDirector {
       identifications.get(0).setOdsIsVerifiedIdentification(Boolean.TRUE);
     }
     return identifications;
+  }
+
+  @Override
+  protected List<ChronometricAge> assembleChronometricAges(JsonNode data, boolean dwc) {
+    var chronometricAges = new ArrayList<ChronometricAge>();
+    var iterateOverElements = true;
+    var count = 0;
+    while (iterateOverElements) {
+      var chronometricAgeNode = getSubJsonAbcd(data, count,
+          List.of("abcd-efg:earthScienceSpecimen:unitStratigraphicDetermination/radiometricDates/radiometricDate"));
+      if (!chronometricAgeNode.isEmpty()) {
+        chronometricAges.add(createChronometricAge(chronometricAgeNode, dwc));
+        count++;
+      } else {
+        iterateOverElements = false;
+      }
+    }
+    return chronometricAges;
   }
 
   private ArrayList<Citation> getCitations(JsonNode data, boolean dwc, String subPath) {

--- a/src/main/java/eu/dissco/core/translator/terms/DwcaDigitalObjectDirector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/DwcaDigitalObjectDirector.java
@@ -6,6 +6,7 @@ import eu.dissco.core.translator.Profiles;
 import eu.dissco.core.translator.component.OrganisationNameComponent;
 import eu.dissco.core.translator.component.SourceSystemComponent;
 import eu.dissco.core.translator.properties.FdoProperties;
+import eu.dissco.core.translator.schema.ChronometricAge;
 import eu.dissco.core.translator.schema.Citation;
 import eu.dissco.core.translator.schema.DigitalSpecimen;
 import eu.dissco.core.translator.schema.Identification;
@@ -90,6 +91,20 @@ public class DwcaDigitalObjectDirector extends BaseDigitalObjectDirector {
       mappedIdentifications.get(0).setOdsIsVerifiedIdentification(Boolean.TRUE);
     }
     return mappedIdentifications;
+  }
+
+  @Override
+  protected List<ChronometricAge> assembleChronometricAges(JsonNode data, boolean dwc) {
+    var mappedChrono = new ArrayList<ChronometricAge>();
+    if (data.get(EXTENSION) != null
+        && data.get(EXTENSION).get("http://rs.tdwg.org/chrono/terms/ChronometricAge") != null) {
+      var chronometricAges = data.get(EXTENSION).get("http://rs.tdwg.org/chrono/terms/ChronometricAge");
+      for (int i = 0; i < chronometricAges.size(); i++) {
+        var chronometricAge = chronometricAges.get(i);
+        mappedChrono.add(createChronometricAge(chronometricAge, dwc));
+      }
+    }
+    return mappedChrono;
   }
 }
 

--- a/src/main/java/eu/dissco/core/translator/terms/Term.java
+++ b/src/main/java/eu/dissco/core/translator/terms/Term.java
@@ -15,6 +15,7 @@ public abstract class Term {
   protected static final String ODS_PREFIX = "ods:";
   protected static final String DWC_PREFIX = "dwc:";
   protected static final String DCTERMS_PREFIX = "dcterms:";
+  protected static final String CHRONO_PREFIX = "chrono:";
   protected static final Pair<String, String> ABCD_NAMED_AREA_KEY =
       Pair.of(
           "abcd:gathering/namedAreas/namedArea/",

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeConversionProtocol.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeConversionProtocol.java
@@ -1,0 +1,22 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class ChronometricAgeConversionProtocol extends Term {
+
+  public static final String TERM = "chrono:chronometricAgeConversionProtocol";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeConversionProtocol.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeConversionProtocol.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class ChronometricAgeConversionProtocol extends Term {
 
-  public static final String TERM = "chrono:chronometricAgeConversionProtocol";
+  public static final String TERM = CHRONO_PREFIX + "chronometricAgeConversionProtocol";
 
   private final List<String> dwcaTerms = List.of(TERM);
 

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeDeterminedBy.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeDeterminedBy.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class ChronometricAgeDeterminedBy extends Term {
 
-  public static final String TERM = "chrono:chronometricAgeDeterminedBy";
+  public static final String TERM = CHRONO_PREFIX + "chronometricAgeDeterminedBy";
 
   private final List<String> dwcaTerms = List.of(TERM);
 

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeDeterminedBy.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeDeterminedBy.java
@@ -1,0 +1,22 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class ChronometricAgeDeterminedBy extends Term {
+
+  public static final String TERM = "chrono:chronometricAgeDeterminedBy";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeDeterminedDate.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeDeterminedDate.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class ChronometricAgeDeterminedDate extends Term {
 
-  public static final String TERM = "chrono:chronometricAgeDeterminedDate";
+  public static final String TERM = CHRONO_PREFIX + "chronometricAgeDeterminedDate";
   private final List<String> abcdTerms = List.of("analysisDateTime/exactDate/dateText",
       "analysisDateTime/dateText");
   private final List<String> dwcaTerms = List.of(TERM);

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeDeterminedDate.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeDeterminedDate.java
@@ -1,0 +1,28 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class ChronometricAgeDeterminedDate extends Term {
+
+  public static final String TERM = "chrono:chronometricAgeDeterminedDate";
+  private final List<String> abcdTerms = List.of("analysisDateTime/exactDate/dateText",
+      "analysisDateTime/dateText");
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeID.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeID.java
@@ -1,0 +1,22 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class ChronometricAgeID extends Term {
+
+  public static final String TERM = "chrono:chronometricAgeID";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeID.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeID.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class ChronometricAgeID extends Term {
 
-  public static final String TERM = "chrono:chronometricAgeID";
+  public static final String TERM = CHRONO_PREFIX + "chronometricAgeID";
 
   private final List<String> dwcaTerms = List.of(TERM);
 

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeProtocol.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeProtocol.java
@@ -1,0 +1,28 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class ChronometricAgeProtocol extends Term {
+
+  public static final String TERM = "chrono:chronometricAgeProtocol";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+  private final List<String> abcdTerms = List.of("radiometricDatingMethod");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeProtocol.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeProtocol.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class ChronometricAgeProtocol extends Term {
 
-  public static final String TERM = "chrono:chronometricAgeProtocol";
+  public static final String TERM = CHRONO_PREFIX + "chronometricAgeProtocol";
 
   private final List<String> dwcaTerms = List.of(TERM);
   private final List<String> abcdTerms = List.of("radiometricDatingMethod");

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeReferences.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeReferences.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class ChronometricAgeReferences extends Term {
 
-  public static final String TERM = "chrono:chronometricAgeReferences";
+  public static final String TERM = CHRONO_PREFIX + "chronometricAgeReferences";
 
   private final List<String> dwcaTerms = List.of(TERM);
   private final List<String> abcdTerms = List.of("analysisReferences/uri",

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeReferences.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeReferences.java
@@ -1,0 +1,29 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class ChronometricAgeReferences extends Term {
+
+  public static final String TERM = "chrono:chronometricAgeReferences";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+  private final List<String> abcdTerms = List.of("analysisReferences/uri",
+      "analysisReferences/titleCitation", "analysisReferences/citationDetail");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeRemarks.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeRemarks.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class ChronometricAgeRemarks extends Term {
 
-  public static final String TERM = "chrono:chronometricAgeRemarks";
+  public static final String TERM = CHRONO_PREFIX + "chronometricAgeRemarks";
 
   private final List<String> dwcaTerms = List.of(TERM);
   private final List<String> abcdTerms = List.of("datingComment");

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeRemarks.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeRemarks.java
@@ -1,0 +1,28 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class ChronometricAgeRemarks extends Term {
+
+  public static final String TERM = "chrono:chronometricAgeRemarks";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+  private final List<String> abcdTerms = List.of("datingComment");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeUncertaintyInYears.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeUncertaintyInYears.java
@@ -1,0 +1,22 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class ChronometricAgeUncertaintyInYears extends Term {
+
+  public static final String TERM = "chrono:chronometricAgeUncertaintyInYears";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeUncertaintyInYears.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeUncertaintyInYears.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class ChronometricAgeUncertaintyInYears extends Term {
 
-  public static final String TERM = "chrono:chronometricAgeUncertaintyInYears";
+  public static final String TERM = CHRONO_PREFIX + "chronometricAgeUncertaintyInYears";
 
   private final List<String> dwcaTerms = List.of(TERM);
 

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeUncertaintyMethod.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeUncertaintyMethod.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class ChronometricAgeUncertaintyMethod extends Term {
 
-  public static final String TERM = "chrono:chronometricAgeUncertaintyMethod";
+  public static final String TERM = CHRONO_PREFIX + "chronometricAgeUncertaintyMethod";
 
   private final List<String> dwcaTerms = List.of(TERM);
 

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeUncertaintyMethod.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeUncertaintyMethod.java
@@ -1,0 +1,22 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class ChronometricAgeUncertaintyMethod extends Term {
+
+  public static final String TERM = "chrono:chronometricAgeUncertaintyMethod";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/EarliestChronometricAge.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/EarliestChronometricAge.java
@@ -1,0 +1,28 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class EarliestChronometricAge extends Term {
+
+  public static final String TERM = "chrono:earliestChronometricAge";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+  private final List<String> abcdTerms = List.of("earliestDate");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/EarliestChronometricAge.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/EarliestChronometricAge.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class EarliestChronometricAge extends Term {
 
-  public static final String TERM = "chrono:earliestChronometricAge";
+  public static final String TERM = CHRONO_PREFIX + "earliestChronometricAge";
 
   private final List<String> dwcaTerms = List.of(TERM);
   private final List<String> abcdTerms = List.of("earliestDate");

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/EarliestChronometricAgeReferenceSystem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/EarliestChronometricAgeReferenceSystem.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class EarliestChronometricAgeReferenceSystem extends Term {
 
-  public static final String TERM = "chrono:earliestChronometricAgeReferenceSystem";
+  public static final String TERM = CHRONO_PREFIX + "earliestChronometricAgeReferenceSystem";
 
   private final List<String> dwcaTerms = List.of(TERM);
   private final List<String> abcdTerms = List.of("timeUnit");

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/EarliestChronometricAgeReferenceSystem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/EarliestChronometricAgeReferenceSystem.java
@@ -1,0 +1,28 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class EarliestChronometricAgeReferenceSystem extends Term {
+
+  public static final String TERM = "chrono:earliestChronometricAgeReferenceSystem";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+  private final List<String> abcdTerms = List.of("timeUnit");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/LatestChronometricAge.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/LatestChronometricAge.java
@@ -1,0 +1,28 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class LatestChronometricAge extends Term {
+
+  public static final String TERM = "chrono:latestChronometricAge";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+  private final List<String> abcdTerms = List.of("latestDate");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/LatestChronometricAge.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/LatestChronometricAge.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class LatestChronometricAge extends Term {
 
-  public static final String TERM = "chrono:latestChronometricAge";
+  public static final String TERM = CHRONO_PREFIX + "latestChronometricAge";
 
   private final List<String> dwcaTerms = List.of(TERM);
   private final List<String> abcdTerms = List.of("latestDate");

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/LatestChronometricAgeReferenceSystem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/LatestChronometricAgeReferenceSystem.java
@@ -1,0 +1,28 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class LatestChronometricAgeReferenceSystem extends Term {
+
+  public static final String TERM = "chrono:latestChronometricAgeReferenceSystem";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+  private final List<String> abcdTerms = List.of("timeUnit");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/LatestChronometricAgeReferenceSystem.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/LatestChronometricAgeReferenceSystem.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class LatestChronometricAgeReferenceSystem extends Term {
 
-  public static final String TERM = "chrono:latestChronometricAgeReferenceSystem";
+  public static final String TERM = CHRONO_PREFIX + "latestChronometricAgeReferenceSystem";
 
   private final List<String> dwcaTerms = List.of(TERM);
   private final List<String> abcdTerms = List.of("timeUnit");

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDated.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDated.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class MaterialDated extends Term {
 
-  public static final String TERM = "chrono:materialDated";
+  public static final String TERM = CHRONO_PREFIX + "materialDated";
 
   private final List<String> dwcaTerms = List.of(TERM);
   private final List<String> abcdTerms = List.of("materialDated");

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDated.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDated.java
@@ -1,0 +1,29 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class MaterialDated extends Term {
+
+  public static final String TERM = "chrono:materialDated";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+  private final List<String> abcdTerms = List.of("materialDated");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDatedID.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDatedID.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class MaterialDatedID extends Term {
 
-  public static final String TERM = "chrono:materialDatedID";
+  public static final String TERM = CHRONO_PREFIX + "materialDatedID";
 
   private final List<String> dwcaTerms = List.of(TERM);
 

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDatedID.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDatedID.java
@@ -1,0 +1,22 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class MaterialDatedID extends Term {
+
+  public static final String TERM = "chrono:materialDatedID";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDatedRelationship.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDatedRelationship.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class MaterialDatedRelationship extends Term {
 
-  public static final String TERM = "chrono:materialDatedRelationship";
+  public static final String TERM = CHRONO_PREFIX + "materialDatedRelationship";
 
   private final List<String> dwcaTerms = List.of(TERM);
 

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDatedRelationship.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDatedRelationship.java
@@ -1,0 +1,22 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class MaterialDatedRelationship extends Term {
+
+  public static final String TERM = "chrono:materialDatedRelationship";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/UncalibratedChronometricAge.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/UncalibratedChronometricAge.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class UncalibratedChronometricAge extends Term {
 
-  public static final String TERM = "chrono:uncalibratedChronometricAge";
+  public static final String TERM = CHRONO_PREFIX + "uncalibratedChronometricAge";
 
   private final List<String> dwcaTerms = List.of(TERM);
 

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/UncalibratedChronometricAge.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/UncalibratedChronometricAge.java
@@ -1,0 +1,22 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class UncalibratedChronometricAge extends Term {
+
+  public static final String TERM = "chrono:uncalibratedChronometricAge";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/VerbatimChronometricAge.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/VerbatimChronometricAge.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class VerbatimChronometricAge extends Term {
 
-  public static final String TERM = "chrono:verbatimChronometricAge";
+  public static final String TERM = CHRONO_PREFIX + "verbatimChronometricAge";
 
   private final List<String> dwcaTerms = List.of(TERM);
   private final List<String> abcdTerms = List.of("datingAccuracy");

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/VerbatimChronometricAge.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/chronometric/VerbatimChronometricAge.java
@@ -1,0 +1,33 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class VerbatimChronometricAge extends Term {
+
+  public static final String TERM = "chrono:verbatimChronometricAge";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+  private final List<String> abcdTerms = List.of("datingAccuracy");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    var value = super.searchJsonForTerm(unit, abcdTerms);
+    if (value != null) {
+      return "ABCDEFG datingAccuracy is: " + value;
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/resources/json-schema/digital-media.json
+++ b/src/main/resources/json-schema/digital-media.json
@@ -227,14 +227,6 @@
         "https://creativecommons.org/licenses/by-nc-sa/4.0/"
       ]
     },
-    "xmpRights:Owner": {
-      "type": "string",
-      "description": "A list of legal owners of the resource",
-      "examples": [
-        "Unknown",
-        "Naturalis Biodiversity Center"
-      ]
-    },
     "dcterms:available": {
       "type": "string",
       "description": "Date (often a range) that the resource became or will become available",

--- a/src/main/resources/json-schema/digital-specimen.json
+++ b/src/main/resources/json-schema/digital-specimen.json
@@ -140,7 +140,8 @@
           "eng",
           "fra",
           "deu"
-        ], [
+        ],
+        [
           "dut"
         ]
       ]
@@ -463,6 +464,14 @@
       "items": {
         "type": "object",
         "$ref": "https://schemas.dissco.tech/schemas/fdo-type/digital-specimen/0.4.0/event.json"
+      }
+    },
+    "ods:hasChronometricAges": {
+      "type": "array",
+      "description": "Contains information about the chronometric age of the specimen part",
+      "items": {
+        "type": "object",
+        "$ref": "https://schemas.dissco.tech/schemas/fdo-type/digital-specimen/0.4.0/chronometric-age.json"
       }
     },
     "ods:hasTombstoneMetadata": {

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeConversionProtocolTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeConversionProtocolTest.java
@@ -1,0 +1,37 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChronometricAgeConversionProtocolTest {
+
+  private static final String AGE_CONVERSION_PROTOCOL_STRING = "INTCAL13";
+  private final ChronometricAgeConversionProtocol chronometricAgeConversionProtocol = new ChronometricAgeConversionProtocol();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:chronometricAgeConversionProtocol", AGE_CONVERSION_PROTOCOL_STRING);
+
+    // When
+    var result = chronometricAgeConversionProtocol.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(AGE_CONVERSION_PROTOCOL_STRING);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = chronometricAgeConversionProtocol.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(ChronometricAgeConversionProtocol.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeDeterminedByTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeDeterminedByTest.java
@@ -1,0 +1,37 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChronometricAgeDeterminedByTest {
+
+  private static final String AGE_DETERMINED_BY_STRING = "Tom Dijkema";
+  private final ChronometricAgeDeterminedBy chronometricAgeDeterminedBy = new ChronometricAgeDeterminedBy();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:chronometricAgeDeterminedBy", AGE_DETERMINED_BY_STRING);
+
+    // When
+    var result = chronometricAgeDeterminedBy.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(AGE_DETERMINED_BY_STRING);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = chronometricAgeDeterminedBy.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(ChronometricAgeDeterminedBy.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeDeterminedDateTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeDeterminedDateTest.java
@@ -1,0 +1,50 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static eu.dissco.core.translator.TestUtils.MOCK_DATE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChronometricAgeDeterminedDateTest {
+
+  private final ChronometricAgeDeterminedDate chronometricAgeDeterminedDate = new ChronometricAgeDeterminedDate();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:chronometricAgeDeterminedDate", MOCK_DATE);
+
+    // When
+    var result = chronometricAgeDeterminedDate.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(MOCK_DATE);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("analysisDateTime/exactDate/dateText", MOCK_DATE);
+
+    // When
+    var result = chronometricAgeDeterminedDate.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(MOCK_DATE);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = chronometricAgeDeterminedDate.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(ChronometricAgeDeterminedDate.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeIDTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeIDTest.java
@@ -1,0 +1,37 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChronometricAgeIDTest {
+
+  private static final String AGE_ID = "https://www.canadianarchaeology.ca/samples/70673";
+  private final ChronometricAgeID chronometricAgeID = new ChronometricAgeID();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:chronometricAgeID", AGE_ID);
+
+    // When
+    var result = chronometricAgeID.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(AGE_ID);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = chronometricAgeID.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(ChronometricAgeID.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeProtocolTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeProtocolTest.java
@@ -1,0 +1,50 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChronometricAgeProtocolTest {
+
+  private static final String AGE_PROTOCOL = "radiocarbon";
+  private final ChronometricAgeProtocol chronometricAgeProtocol = new ChronometricAgeProtocol();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:chronometricAgeProtocol", AGE_PROTOCOL);
+
+    // When
+    var result = chronometricAgeProtocol.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(AGE_PROTOCOL);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("radiometricDatingMethod", AGE_PROTOCOL);
+
+    // When
+    var result = chronometricAgeProtocol.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(AGE_PROTOCOL);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = chronometricAgeProtocol.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(ChronometricAgeProtocol.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeReferencesTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeReferencesTest.java
@@ -1,0 +1,50 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChronometricAgeReferencesTest {
+
+  private static final String REFERENCE = "https://doi.org/10.1007/s10814-019-09140-x";
+  private final ChronometricAgeReferences chronometricAgeReferences = new ChronometricAgeReferences();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:chronometricAgeReferences", REFERENCE);
+
+    // When
+    var result = chronometricAgeReferences.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(REFERENCE);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("analysisReferences/uri", REFERENCE);
+
+    // When
+    var result = chronometricAgeReferences.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(REFERENCE);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = chronometricAgeReferences.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(ChronometricAgeReferences.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeRemarksTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeRemarksTest.java
@@ -1,0 +1,50 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChronometricAgeRemarksTest {
+
+  private static final String REMARK = "Beta Analytic number: 323913";
+  private final ChronometricAgeRemarks chronometricAgeRemarks = new ChronometricAgeRemarks();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:chronometricAgeRemarks", REMARK);
+
+    // When
+    var result = chronometricAgeRemarks.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(REMARK);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("datingComment", REMARK);
+
+    // When
+    var result = chronometricAgeRemarks.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(REMARK);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = chronometricAgeRemarks.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(ChronometricAgeRemarks.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeUncertaintyInYearsTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeUncertaintyInYearsTest.java
@@ -1,0 +1,37 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChronometricAgeUncertaintyInYearsTest {
+
+  private static final String UNCERTAINTY_IN_YEARS = "1500";
+  private final ChronometricAgeUncertaintyInYears chronometricAgeUncertaintyInYears = new ChronometricAgeUncertaintyInYears();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:chronometricAgeUncertaintyInYears", UNCERTAINTY_IN_YEARS);
+
+    // When
+    var result = chronometricAgeUncertaintyInYears.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(UNCERTAINTY_IN_YEARS);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = chronometricAgeUncertaintyInYears.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(ChronometricAgeUncertaintyInYears.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeUncertaintyMethodTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/ChronometricAgeUncertaintyMethodTest.java
@@ -1,0 +1,37 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChronometricAgeUncertaintyMethodTest {
+
+  private static final String UNCERTAINTY_METHOD = "Half of 95% confidence interval";
+  private final ChronometricAgeUncertaintyMethod chronometricAgeUncertaintyMethod = new ChronometricAgeUncertaintyMethod();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:chronometricAgeUncertaintyMethod", UNCERTAINTY_METHOD);
+
+    // When
+    var result = chronometricAgeUncertaintyMethod.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(UNCERTAINTY_METHOD);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = chronometricAgeUncertaintyMethod.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(ChronometricAgeUncertaintyMethod.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/EarliestChronometricAgeReferenceSystemTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/EarliestChronometricAgeReferenceSystemTest.java
@@ -1,0 +1,50 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EarliestChronometricAgeReferenceSystemTest {
+
+  private static final String EARLIEST_AGE_REFERENCE_SYSTEM = "BP";
+  private final EarliestChronometricAgeReferenceSystem earliestChronometricAgeReferenceSystem = new EarliestChronometricAgeReferenceSystem();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:earliestChronometricAgeReferenceSystem", EARLIEST_AGE_REFERENCE_SYSTEM);
+
+    // When
+    var result = earliestChronometricAgeReferenceSystem.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(EARLIEST_AGE_REFERENCE_SYSTEM);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("timeUnit", EARLIEST_AGE_REFERENCE_SYSTEM);
+
+    // When
+    var result = earliestChronometricAgeReferenceSystem.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(EARLIEST_AGE_REFERENCE_SYSTEM);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = earliestChronometricAgeReferenceSystem.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(EarliestChronometricAgeReferenceSystem.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/EarliestChronometricAgeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/EarliestChronometricAgeTest.java
@@ -1,0 +1,50 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EarliestChronometricAgeTest {
+
+  private static final String EARLIEST_AGE = "100";
+  private final EarliestChronometricAge earliestChronometricAge = new EarliestChronometricAge();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:earliestChronometricAge", EARLIEST_AGE);
+
+    // When
+    var result = earliestChronometricAge.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(EARLIEST_AGE);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("earliestDate", EARLIEST_AGE);
+
+    // When
+    var result = earliestChronometricAge.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(EARLIEST_AGE);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = earliestChronometricAge.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(EarliestChronometricAge.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/LatestChronometricAgeReferenceSystemTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/LatestChronometricAgeReferenceSystemTest.java
@@ -1,0 +1,50 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LatestChronometricAgeReferenceSystemTest {
+
+  private static final String LATEST_AGE_REFERENCE_SYSTEM = "BP";
+  private final LatestChronometricAgeReferenceSystem earliestChronometricAgeReferenceSystem = new LatestChronometricAgeReferenceSystem();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:latestChronometricAgeReferenceSystem", LATEST_AGE_REFERENCE_SYSTEM);
+
+    // When
+    var result = earliestChronometricAgeReferenceSystem.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(LATEST_AGE_REFERENCE_SYSTEM);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("timeUnit", LATEST_AGE_REFERENCE_SYSTEM);
+
+    // When
+    var result = earliestChronometricAgeReferenceSystem.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(LATEST_AGE_REFERENCE_SYSTEM);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = earliestChronometricAgeReferenceSystem.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(LatestChronometricAgeReferenceSystem.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/LatestChronometricAgeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/LatestChronometricAgeTest.java
@@ -1,0 +1,50 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LatestChronometricAgeTest {
+
+  private static final String LATEST_AGE = "100";
+  private final LatestChronometricAge latestChronometricAge = new LatestChronometricAge();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:latestChronometricAge", LATEST_AGE);
+
+    // When
+    var result = latestChronometricAge.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(LATEST_AGE);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("latestDate", LATEST_AGE);
+
+    // When
+    var result = latestChronometricAge.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(LATEST_AGE);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = latestChronometricAge.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(LatestChronometricAge.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDatedIDTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDatedIDTest.java
@@ -1,0 +1,37 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MaterialDatedIDTest {
+
+  private static final String MATERIAL_DATED_ID_STRING = "dwc:materialSampleID: https://www.ebi.ac.uk/metagenomics/samples/SRS1930158";
+  private final MaterialDatedID materialDatedID = new MaterialDatedID();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:materialDatedID", MATERIAL_DATED_ID_STRING);
+
+    // When
+    var result = materialDatedID.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(MATERIAL_DATED_ID_STRING);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = materialDatedID.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MaterialDatedID.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDatedRelationshipTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDatedRelationshipTest.java
@@ -1,0 +1,37 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MaterialDatedRelationshipTest {
+
+  private static final String MATERIAL_RELATIONSHIP = "stratigraphicallyCorrelatedWith";
+  private final MaterialDatedRelationship materialDatedRelationship = new MaterialDatedRelationship();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:materialDatedRelationship", MATERIAL_RELATIONSHIP);
+
+    // When
+    var result = materialDatedRelationship.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(MATERIAL_RELATIONSHIP);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = materialDatedRelationship.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MaterialDatedRelationship.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDatedTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/MaterialDatedTest.java
@@ -1,0 +1,50 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MaterialDatedTest {
+
+  private static final String MATERIAL_DATED_STRING = "charred wood";
+  private final MaterialDated materialDated = new MaterialDated();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:materialDated", MATERIAL_DATED_STRING);
+
+    // When
+    var result = materialDated.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(MATERIAL_DATED_STRING);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("materialDated", MATERIAL_DATED_STRING);
+
+    // When
+    var result = materialDated.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(MATERIAL_DATED_STRING);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = materialDated.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MaterialDated.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/UncalibratedChronometricAgeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/UncalibratedChronometricAgeTest.java
@@ -1,0 +1,37 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UncalibratedChronometricAgeTest {
+
+  private static final String UNCALIBRATED = "1510 +/- 25 14C yr BP";
+  private final UncalibratedChronometricAge uncalibratedChronometricAge = new UncalibratedChronometricAge();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:uncalibratedChronometricAge", UNCALIBRATED);
+
+    // When
+    var result = uncalibratedChronometricAge.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(UNCALIBRATED);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = uncalibratedChronometricAge.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(UncalibratedChronometricAge.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/VerbatimChronometricAgeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/chronometric/VerbatimChronometricAgeTest.java
@@ -1,0 +1,50 @@
+package eu.dissco.core.translator.terms.specimen.chronometric;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class VerbatimChronometricAgeTest {
+
+  private static final String VERBATIM = "27 BC to 14 AD";
+  private final VerbatimChronometricAge uncalibratedChronometricAge = new VerbatimChronometricAge();
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("chrono:verbatimChronometricAge", VERBATIM);
+
+    // When
+    var result = uncalibratedChronometricAge.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(VERBATIM);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("datingAccuracy", VERBATIM);
+
+    // When
+    var result = uncalibratedChronometricAge.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo("ABCDEFG datingAccuracy is: " + VERBATIM);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = uncalibratedChronometricAge.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(VerbatimChronometricAge.TERM);
+  }
+}


### PR DESCRIPTION
- Add mapping to chronometric age 

Difficult to test as no DiSSCo dataset uses the dwca extension nor any of the biocase use the abcdefg fields.
There are lots of improvements to be made but first let's do this default mapping as nobody is using this yet anyway