### PR TITLE
Add sanitize logic to location meter field

### DIFF
--- a/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
@@ -174,6 +174,7 @@ import eu.dissco.core.translator.terms.specimen.identification.taxonomy.Taxonomi
 import eu.dissco.core.translator.terms.specimen.identification.taxonomy.Tribe;
 import eu.dissco.core.translator.terms.specimen.identification.taxonomy.VerbatimTaxonRank;
 import eu.dissco.core.translator.terms.specimen.identification.taxonomy.VernacularName;
+import eu.dissco.core.translator.terms.specimen.location.AbstractMeterTerm;
 import eu.dissco.core.translator.terms.specimen.location.Continent;
 import eu.dissco.core.translator.terms.specimen.location.Country;
 import eu.dissco.core.translator.terms.specimen.location.CountryCode;
@@ -251,6 +252,17 @@ public abstract class BaseDigitalObjectDirector {
   private final SourceSystemComponent sourceSystemComponent;
   private final FdoProperties fdoProperties;
   private final List<String> identifierTerms;
+
+  private static Double stringToDouble(Term term, String value) {
+    try {
+      if (value != null) {
+        return Double.valueOf(value);
+      }
+    } catch (NumberFormatException ex) {
+      log.warn("Unable to parse value: {} to a double for term: {}", value, term.getTerm());
+    }
+    return null;
+  }
 
   public DigitalSpecimen assembleDigitalSpecimenTerm(JsonNode data, boolean dwc)
       throws OrganisationException, UnknownPhysicalSpecimenIdType {
@@ -455,7 +467,6 @@ public abstract class BaseDigitalObjectDirector {
     return identification;
   }
 
-
   private List<Event> assembleEventTerms(JsonNode data, boolean dwc) {
     var geoReference = new Georeference()
         .withType("ods:Georeference")
@@ -531,14 +542,10 @@ public abstract class BaseDigitalObjectDirector {
         .withDwcStateProvince(termMapper.retrieveTerm(new StateProvince(), data, dwc))
         .withDwcWaterBody(termMapper.retrieveTerm(new WaterBody(), data, dwc))
         .withDwcHigherGeography(termMapper.retrieveTerm(new HigherGeography(), data, dwc))
-        .withDwcMaximumDepthInMeters(parseToDouble(new MaximumDepthInMeters(), data, dwc))
         .withDwcMaximumDistanceAboveSurfaceInMeters(
             parseToDouble(new MaximumDistanceAboveSurfaceInMeters(), data, dwc))
-        .withDwcMaximumElevationInMeters(parseToDouble(new MaximumElevationInMeters(), data, dwc))
-        .withDwcMinimumDepthInMeters(parseToDouble(new MinimumDepthInMeters(), data, dwc))
         .withDwcMinimumDistanceAboveSurfaceInMeters(
             parseToDouble(new MinimumDistanceAboveSurfaceInMeters(), data, dwc))
-        .withDwcMinimumElevationInMeters(parseToDouble(new MinimumElevationInMeters(), data, dwc))
         .withDwcVerbatimDepth(termMapper.retrieveTerm(new VerbatimDepth(), data, dwc))
         .withDwcVerbatimElevation(termMapper.retrieveTerm(new VerbatimElevation(), data, dwc))
         .withDwcVerticalDatum(termMapper.retrieveTerm(new VerticalDatum(), data, dwc))
@@ -546,6 +553,10 @@ public abstract class BaseDigitalObjectDirector {
         .withDwcLocationRemarks(termMapper.retrieveTerm(new LocationRemarks(), data, dwc))
         .withOdsHasGeoreference(geoReference)
         .withOdsHasGeologicalContext(geologicalContext);
+    setMinMaxMeterField(new MinimumElevationInMeters(), location, data, dwc);
+    setMinMaxMeterField(new MaximumElevationInMeters(), location, data, dwc);
+    setMinMaxMeterField(new MinimumDepthInMeters(), location, data, dwc);
+    setMinMaxMeterField(new MaximumDepthInMeters(), location, data, dwc);
     var assertions = new EventAssertions().gatherEventAssertions(mapper, data, dwc);
     var event = new Event()
         .withType("ods:Event")
@@ -585,6 +596,31 @@ public abstract class BaseDigitalObjectDirector {
     return List.of(event);
   }
 
+  private void setMinMaxMeterField(AbstractMeterTerm term, Location location, JsonNode data,
+      boolean dwc) {
+    var sanitizedValue = termMapper.retrieveTerm(term, data, dwc);
+    var doubleElevation = stringToDouble(term, sanitizedValue);
+    if (doubleElevation == null && sanitizedValue != null) {
+      if (term instanceof MaximumElevationInMeters) {
+        location.setDwcVerbatimElevation(
+            location.getDwcVerbatimElevation() + "| unparseable value maximumElevationInMeters: "
+                + sanitizedValue);
+      } else if (term instanceof MinimumElevationInMeters) {
+        location.setDwcVerbatimElevation(
+            location.getDwcVerbatimElevation() + "| unparseable value minimumElevationInMeters: "
+                + sanitizedValue);
+      } else if (term instanceof MaximumDepthInMeters) {
+        location.setDwcVerbatimDepth(
+            location.getDwcVerbatimDepth() + "| unparseable value maximumDepthInMeters: "
+                + sanitizedValue);
+      } else if (term instanceof MinimumDepthInMeters) {
+        location.setDwcVerbatimDepth(
+            location.getDwcVerbatimDepth() + "| unparseable value minimumDepthInMeters: "
+                + sanitizedValue);
+      }
+    }
+  }
+
   private <T extends Enum<T>> T retrieveEnum(Term term, JsonNode data, boolean dwc,
       java.lang.Class<T> enumClass) {
     var value = termMapper.retrieveTerm(term, data, dwc);
@@ -612,14 +648,7 @@ public abstract class BaseDigitalObjectDirector {
 
   private Double parseToDouble(Term term, JsonNode data, boolean dwc) {
     var value = termMapper.retrieveTerm(term, data, dwc);
-    try {
-      if (value != null) {
-        return Double.valueOf(value);
-      }
-    } catch (NumberFormatException ex) {
-      log.warn("Unable to parse value: {} to a double for term: {}", value, term.getTerm());
-    }
-    return null;
+    return stringToDouble(term, value);
   }
 
   private Boolean parseToBoolean(Term term, JsonNode data, boolean dwc) {

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/AbstractMeterTerm.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/AbstractMeterTerm.java
@@ -1,0 +1,25 @@
+package eu.dissco.core.translator.terms.specimen.location;
+
+import eu.dissco.core.translator.terms.Term;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class AbstractMeterTerm extends Term {
+
+  private static final Pattern M_PATTERN = Pattern.compile("((-\\s?)?\\d+([.,]\\d+)?)\\s*m\\.?(eter)?(tr)?(\\sm.?)?");
+
+  protected String sanitizeInput(String input) {
+    input = input.trim().toLowerCase();
+    Matcher matcher = M_PATTERN.matcher(input);
+    if (matcher.matches()) {
+      log.debug("Parsed Number: {}", matcher.group(1));
+      return matcher.group(1);
+    } else {
+      log.debug("Input string does not match the expected format: {}", input);
+      return input;
+    }
+  }
+
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/MaximumDepthInMeters.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/MaximumDepthInMeters.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
 
-public class MaximumDepthInMeters extends Term {
+public class MaximumDepthInMeters extends AbstractMeterTerm {
 
   public static final String TERM = DWC_PREFIX + "maximumDepthInMeters";
 
@@ -15,12 +15,22 @@ public class MaximumDepthInMeters extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    var rawResult = super.searchJsonForTerm(unit, dwcaTerms);
+    if (rawResult != null) {
+      return sanitizeInput(rawResult);
+    } else {
+      return null;
+    }
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    var rawResult = super.searchJsonForTerm(unit, abcdTerms);
+    if (rawResult != null) {
+      return sanitizeInput(rawResult);
+    } else {
+      return null;
+    }
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/MaximumDistanceAboveSurfaceInMeters.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/MaximumDistanceAboveSurfaceInMeters.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
 
-public class MaximumDistanceAboveSurfaceInMeters extends Term {
+public class MaximumDistanceAboveSurfaceInMeters extends AbstractMeterTerm {
 
   public static final String TERM = DWC_PREFIX + "maximumDistanceAboveSurfaceInMeters";
 
@@ -14,12 +14,22 @@ public class MaximumDistanceAboveSurfaceInMeters extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    var rawResult = super.searchJsonForTerm(unit, dwcaTerms);
+    if (rawResult != null) {
+      return sanitizeInput(rawResult);
+    } else {
+      return null;
+    }
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    var rawResult = super.searchJsonForTerm(unit, abcdTerms);
+    if (rawResult != null) {
+      return sanitizeInput(rawResult);
+    } else {
+      return null;
+    }
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/MaximumElevationInMeters.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/MaximumElevationInMeters.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
 
-public class MaximumElevationInMeters extends Term {
+public class MaximumElevationInMeters extends AbstractMeterTerm {
 
   public static final String TERM = DWC_PREFIX + "maximumElevationInMeters";
 
@@ -15,12 +15,22 @@ public class MaximumElevationInMeters extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    var rawResult = super.searchJsonForTerm(unit, dwcaTerms);
+    if (rawResult != null) {
+      return sanitizeInput(rawResult);
+    } else {
+      return null;
+    }
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    var rawResult = super.searchJsonForTerm(unit, abcdTerms);
+    if (rawResult != null) {
+      return sanitizeInput(rawResult);
+    } else {
+      return null;
+    }
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/MinimumDepthInMeters.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/MinimumDepthInMeters.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
 
-public class MinimumDepthInMeters extends Term {
+public class MinimumDepthInMeters extends AbstractMeterTerm {
 
   public static final String TERM = DWC_PREFIX + "minimumDepthInMeters";
 
@@ -15,12 +15,22 @@ public class MinimumDepthInMeters extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    var rawResult = super.searchJsonForTerm(unit, dwcaTerms);
+    if (rawResult != null) {
+      return sanitizeInput(rawResult);
+    } else {
+      return null;
+    }
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    var rawResult = super.searchJsonForTerm(unit, abcdTerms);
+    if (rawResult != null) {
+      return sanitizeInput(rawResult);
+    } else {
+      return null;
+    }
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/MinimumDistanceAboveSurfaceInMeters.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/MinimumDistanceAboveSurfaceInMeters.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
 
-public class MinimumDistanceAboveSurfaceInMeters extends Term {
+public class MinimumDistanceAboveSurfaceInMeters extends AbstractMeterTerm {
 
   public static final String TERM = DWC_PREFIX + "minimumDistanceAboveSurfaceInMeters";
 
@@ -14,12 +14,22 @@ public class MinimumDistanceAboveSurfaceInMeters extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    var rawResult = super.searchJsonForTerm(unit, dwcaTerms);
+    if (rawResult != null) {
+      return sanitizeInput(rawResult);
+    } else {
+      return null;
+    }
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    var rawResult = super.searchJsonForTerm(unit, abcdTerms);
+    if (rawResult != null) {
+      return sanitizeInput(rawResult);
+    } else {
+      return null;
+    }
   }
 
   @Override

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/location/MinimumElevationInMeters.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/location/MinimumElevationInMeters.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
 
-public class MinimumElevationInMeters extends Term {
+public class MinimumElevationInMeters extends AbstractMeterTerm {
 
   public static final String TERM = DWC_PREFIX + "minimumElevationInMeters";
 
@@ -15,12 +15,22 @@ public class MinimumElevationInMeters extends Term {
 
   @Override
   public String retrieveFromDWCA(JsonNode unit) {
-    return super.searchJsonForTerm(unit, dwcaTerms);
+    var rawResult = super.searchJsonForTerm(unit, dwcaTerms);
+    if (rawResult != null) {
+      return sanitizeInput(rawResult);
+    } else {
+      return null;
+    }
   }
 
   @Override
   public String retrieveFromABCD(JsonNode unit) {
-    return super.searchJsonForTerm(unit, abcdTerms);
+    var rawResult = super.searchJsonForTerm(unit, abcdTerms);
+    if (rawResult != null) {
+      return sanitizeInput(rawResult);
+    } else {
+      return null;
+    }
   }
 
   @Override

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/MaximumDepthInMetersTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/MaximumDepthInMetersTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -13,11 +15,12 @@ class MaximumDepthInMetersTest {
   private static final String MAXIMUM_DEPTH_IN_METERS_STRING = "-350";
   private final MaximumDepthInMeters maximumDepthInMeters = new MaximumDepthInMeters();
 
-  @Test
-  void testRetrieveFromDWCA() {
+  @ParameterizedTest
+  @ValueSource(strings = {"-350m.", "-350meter", "-350 m", "-350 MTR"})
+  void testRetrieveFromDWCA(String input) {
     // Given
     var unit = MAPPER.createObjectNode();
-    unit.put("dwc:maximumDepthInMeters", MAXIMUM_DEPTH_IN_METERS_STRING);
+    unit.put("dwc:maximumDepthInMeters", input);
 
     // When
     var result = maximumDepthInMeters.retrieveFromDWCA(unit);
@@ -27,17 +30,44 @@ class MaximumDepthInMetersTest {
   }
 
   @Test
-  void testRetrieveFromABCD() {
+  void testRetrieveFromDWCANull() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.putNull("dwc:maximumDepthInMeters");
+
+    // When
+    var result = maximumDepthInMeters.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"-350", "-350.0", "-350.00", "-350.000"})
+  void testRetrieveFromABCD(String input) {
     // Given
     var unit = MAPPER.createObjectNode();
     unit.put("abcd:gathering/depth/measurementOrFactAtomised/upperValue/value",
-        MAXIMUM_DEPTH_IN_METERS_STRING);
+        input);
 
     // When
     var result = maximumDepthInMeters.retrieveFromABCD(unit);
 
     // Then
     assertThat(result).isEqualTo(MAXIMUM_DEPTH_IN_METERS_STRING);
+  }
+
+  @Test
+  void testRetrieveFromABCDNull() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.putNull("abcd:gathering/depth/measurementOrFactAtomised/upperValue/value");
+
+    // When
+    var result = maximumDepthInMeters.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isNull();
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/MaximumDistanceAboveSurfaceInMetersTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/MaximumDistanceAboveSurfaceInMetersTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -13,12 +15,12 @@ class MaximumDistanceAboveSurfaceInMetersTest {
   private static final String MAXIMUM_DISTANCE_ABOVE_SURFACE_IN_METERS_STRING = "350";
   private final MaximumDistanceAboveSurfaceInMeters maximumDistanceAboveSurfaceInMeters = new MaximumDistanceAboveSurfaceInMeters();
 
-  @Test
-  void testRetrieveFromDWCA() {
+  @ParameterizedTest
+  @ValueSource(strings = {"350m.", "350meter", "350 m m", "350 mtr"})
+  void testRetrieveFromDWCA(String input) {
     // Given
     var unit = MAPPER.createObjectNode();
-    unit.put("dwc:maximumDistanceAboveSurfaceInMeters",
-        MAXIMUM_DISTANCE_ABOVE_SURFACE_IN_METERS_STRING);
+    unit.put("dwc:maximumDistanceAboveSurfaceInMeters", input);
 
     // When
     var result = maximumDistanceAboveSurfaceInMeters.retrieveFromDWCA(unit);
@@ -28,17 +30,43 @@ class MaximumDistanceAboveSurfaceInMetersTest {
   }
 
   @Test
-  void testRetrieveFromABCD() {
+  void testRetrieveFromDWCANull() {
     // Given
     var unit = MAPPER.createObjectNode();
-    unit.put("abcd:gathering/height/measurementOrFactAtomised/upperValue/value",
-        MAXIMUM_DISTANCE_ABOVE_SURFACE_IN_METERS_STRING);
+    unit.putNull("dwc:maximumDistanceAboveSurfaceInMeters");
+
+    // When
+    var result = maximumDistanceAboveSurfaceInMeters.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"350m.", "350meter", "350 m m", "350 mtr"})
+  void testRetrieveFromABCD(String input) {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("abcd:gathering/height/measurementOrFactAtomised/upperValue/value", input);
 
     // When
     var result = maximumDistanceAboveSurfaceInMeters.retrieveFromABCD(unit);
 
     // Then
     assertThat(result).isEqualTo(MAXIMUM_DISTANCE_ABOVE_SURFACE_IN_METERS_STRING);
+  }
+
+  @Test
+  void testRetrieveFromABCDNull() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.putNull("abcd:gathering/height/measurementOrFactAtomised/upperValue/value");
+
+    // When
+    var result = maximumDistanceAboveSurfaceInMeters.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isNull();
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/MaximumElevationInMetersTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/MaximumElevationInMetersTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -13,11 +15,12 @@ class MaximumElevationInMetersTest {
   private static final String MAXIMUM_ELEVATION_IN_METERS_STRING = "350";
   private final MaximumElevationInMeters maximumElevationInMeters = new MaximumElevationInMeters();
 
-  @Test
-  void testRetrieveFromDWCA() {
+  @ParameterizedTest
+  @ValueSource(strings = {"350m.", "350meter", "350 m", "350 MTR"})
+  void testRetrieveFromDWCA(String input) {
     // Given
     var unit = MAPPER.createObjectNode();
-    unit.put("dwc:maximumElevationInMeters", MAXIMUM_ELEVATION_IN_METERS_STRING);
+    unit.put("dwc:maximumElevationInMeters", input);
 
     // When
     var result = maximumElevationInMeters.retrieveFromDWCA(unit);
@@ -27,17 +30,43 @@ class MaximumElevationInMetersTest {
   }
 
   @Test
-  void testRetrieveFromABCD() {
+  void testRetrieveFromDWCANull() {
     // Given
     var unit = MAPPER.createObjectNode();
-    unit.put("abcd:gathering/altitude/measurementOrFactAtomised/upperValue/value",
-        MAXIMUM_ELEVATION_IN_METERS_STRING);
+    unit.putNull("dwc:maximumElevationInMeters");
+
+    // When
+    var result = maximumElevationInMeters.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"350m.", "350meter", "350 m", "350 MTR"})
+  void testRetrieveFromABCD(String input) {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("abcd:gathering/altitude/measurementOrFactAtomised/upperValue/value", input);
 
     // When
     var result = maximumElevationInMeters.retrieveFromABCD(unit);
 
     // Then
     assertThat(result).isEqualTo(MAXIMUM_ELEVATION_IN_METERS_STRING);
+  }
+
+  @Test
+  void testRetrieveFromABCDNull() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.putNull("abcd:gathering/altitude/measurementOrFactAtomised/upperValue/value");
+
+    // When
+    var result = maximumElevationInMeters.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isNull();
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/MinimumDepthInMetersTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/MinimumDepthInMetersTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -13,11 +15,12 @@ class MinimumDepthInMetersTest {
   private static final String MINIMUM_DEPTH_IN_METERS_STRING = "-50";
   private final MinimumDepthInMeters minimumDepthInMeters = new MinimumDepthInMeters();
 
-  @Test
-  void testRetrieveFromDWCA() {
+  @ParameterizedTest
+  @ValueSource(strings = {"-50m.", "-50meter", "-50 m", "-50 MTR"})
+  void testRetrieveFromDWCA(String input) {
     // Given
     var unit = MAPPER.createObjectNode();
-    unit.put("dwc:minimumDepthInMeters", MINIMUM_DEPTH_IN_METERS_STRING);
+    unit.put("dwc:minimumDepthInMeters", input);
 
     // When
     var result = minimumDepthInMeters.retrieveFromDWCA(unit);
@@ -27,17 +30,43 @@ class MinimumDepthInMetersTest {
   }
 
   @Test
-  void testRetrieveFromABCD() {
+  void testRetrieveFromDWCANull() {
     // Given
     var unit = MAPPER.createObjectNode();
-    unit.put("abcd:gathering/depth/measurementOrFactAtomised/lowerValue/value",
-        MINIMUM_DEPTH_IN_METERS_STRING);
+    unit.putNull("dwc:minimumDepthInMeters");
+
+    // When
+    var result = minimumDepthInMeters.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"-50m.", "-50meter", "-50 m", "-50 MTR"})
+  void testRetrieveFromABCD(String input) {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("abcd:gathering/depth/measurementOrFactAtomised/lowerValue/value", input);
 
     // When
     var result = minimumDepthInMeters.retrieveFromABCD(unit);
 
     // Then
     assertThat(result).isEqualTo(MINIMUM_DEPTH_IN_METERS_STRING);
+  }
+
+  @Test
+  void testRetrieveFromNull() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.putNull("abcd:gathering/depth/measurementOrFactAtomised/lowerValue/value");
+
+    // When
+    var result = minimumDepthInMeters.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isNull();
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/MinimumDistanceAboveSurfaceInMetersTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/MinimumDistanceAboveSurfaceInMetersTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -13,12 +15,12 @@ class MinimumDistanceAboveSurfaceInMetersTest {
   private static final String MINIMUM_DISTANCE_ABOVE_SURFACE_IN_METERS_STRING = "250";
   private final MinimumDistanceAboveSurfaceInMeters minimumDistanceAboveSurfaceInMeters = new MinimumDistanceAboveSurfaceInMeters();
 
-  @Test
-  void testRetrieveFromDWCA() {
+  @ParameterizedTest
+  @ValueSource(strings = {"250m.  ", "250 meter", "250 m", "250 MTR"})
+  void testRetrieveFromDWCA(String input) {
     // Given
     var unit = MAPPER.createObjectNode();
-    unit.put("dwc:minimumDistanceAboveSurfaceInMeters",
-        MINIMUM_DISTANCE_ABOVE_SURFACE_IN_METERS_STRING);
+    unit.put("dwc:minimumDistanceAboveSurfaceInMeters", input);
 
     // When
     var result = minimumDistanceAboveSurfaceInMeters.retrieveFromDWCA(unit);
@@ -28,17 +30,43 @@ class MinimumDistanceAboveSurfaceInMetersTest {
   }
 
   @Test
-  void testRetrieveFromABCD() {
+  void testRetrieveFromDWCANull() {
     // Given
     var unit = MAPPER.createObjectNode();
-    unit.put("abcd:gathering/height/measurementOrFactAtomised/lowerValue/value",
-        MINIMUM_DISTANCE_ABOVE_SURFACE_IN_METERS_STRING);
+    unit.putNull("dwc:minimumDistanceAboveSurfaceInMeters");
+
+    // When
+    var result = minimumDistanceAboveSurfaceInMeters.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"250m.  ", "250 meter", "250 m", "250 MTR"})
+  void testRetrieveFromABCD(String input) {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("abcd:gathering/height/measurementOrFactAtomised/lowerValue/value", input);
 
     // When
     var result = minimumDistanceAboveSurfaceInMeters.retrieveFromABCD(unit);
 
     // Then
     assertThat(result).isEqualTo(MINIMUM_DISTANCE_ABOVE_SURFACE_IN_METERS_STRING);
+  }
+
+  @Test
+  void testRetrieveFromABCDNull() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.putNull("abcd:gathering/height/measurementOrFactAtomised/lowerValue/value");
+
+    // When
+    var result = minimumDistanceAboveSurfaceInMeters.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isNull();
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/location/MinimumElevationInMetersTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/location/MinimumElevationInMetersTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -13,11 +15,12 @@ class MinimumElevationInMetersTest {
   private static final String MINIMUM_ELEVATION_IN_METERS_STRING = "250";
   private final MinimumElevationInMeters minimumElevationInMeters = new MinimumElevationInMeters();
 
-  @Test
-  void testRetrieveFromDWCA() {
+  @ParameterizedTest
+  @ValueSource(strings = {"250m.  ", "250 meter", "250 m", "250 MTR"})
+  void testRetrieveFromDWCA(String input) {
     // Given
     var unit = MAPPER.createObjectNode();
-    unit.put("dwc:minimumElevationInMeters", MINIMUM_ELEVATION_IN_METERS_STRING);
+    unit.put("dwc:minimumElevationInMeters", input);
 
     // When
     var result = minimumElevationInMeters.retrieveFromDWCA(unit);
@@ -27,17 +30,43 @@ class MinimumElevationInMetersTest {
   }
 
   @Test
-  void testRetrieveFromABCD() {
+  void testRetrieveFromDWCANull() {
     // Given
     var unit = MAPPER.createObjectNode();
-    unit.put("abcd:gathering/altitude/measurementOrFactAtomised/lowerValue/value",
-        MINIMUM_ELEVATION_IN_METERS_STRING);
+    unit.putNull("dwc:minimumElevationInMeters");
+
+    // When
+    var result = minimumElevationInMeters.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"250m.  ", "250 meter", "250 m", "250 MTR"})
+  void testRetrieveFromABCD(String input) {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("abcd:gathering/altitude/measurementOrFactAtomised/lowerValue/value", input);
 
     // When
     var result = minimumElevationInMeters.retrieveFromABCD(unit);
 
     // Then
     assertThat(result).isEqualTo(MINIMUM_ELEVATION_IN_METERS_STRING);
+  }
+
+  @Test
+  void testRetrieveFromABCDNull() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.putNull("abcd:gathering/altitude/measurementOrFactAtomised/lowerValue/value");
+
+    // When
+    var result = minimumElevationInMeters.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isNull();
   }
 
   @Test


### PR DESCRIPTION
- Use regex to sanitize xxxMeter field. Ingestion shows that there are often some simple issues with it. This logic uses regEx to remove the `m.` `m` `meter` mtr` and a couple of other options from the string. This enables parsing it to double and putting it in the field in a lot of cases.
- When we cannot parse the field try to add it to a verbatim field when available (for distanceAboveSurface it is not available)