### PR TITLE
Only add objects when not empty

### DIFF
--- a/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
@@ -267,11 +267,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public abstract class BaseDigitalObjectDirector {
 
-  private final static Georeference EMPTY_GEOREFERENCE = new Georeference().withType(
+  private static final Georeference EMPTY_GEOREFERENCE = new Georeference().withType(
       "ods:Georeference");
-  private final static GeologicalContext EMPTY_GEOLOGICAL_CONTEXT = new GeologicalContext().withType(
+  private static final GeologicalContext EMPTY_GEOLOGICAL_CONTEXT = new GeologicalContext().withType(
       "ods:GeologicalContext");
-  private final static Location EMPTY_LOCATION = new Location().withType("ods:Location");
+  private static final Location EMPTY_LOCATION = new Location().withType("ods:Location");
 
   protected final ObjectMapper mapper;
   protected final TermMapper termMapper;

--- a/src/main/java/eu/dissco/core/translator/terms/DwcaDigitalObjectDirector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/DwcaDigitalObjectDirector.java
@@ -12,6 +12,7 @@ import eu.dissco.core.translator.schema.DigitalSpecimen;
 import eu.dissco.core.translator.schema.Identification;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Component;
 public class DwcaDigitalObjectDirector extends BaseDigitalObjectDirector {
 
   private static final String EXTENSION = "extensions";
+  private static final Citation EMTPY_CITATION = new Citation().withType("ods:Citation");
 
   public DwcaDigitalObjectDirector(ObjectMapper mapper, TermMapper termMapper,
       OrganisationNameComponent rorComponent, SourceSystemComponent sourceSystemComponent,
@@ -61,7 +63,10 @@ public class DwcaDigitalObjectDirector extends BaseDigitalObjectDirector {
         }
       }
     } else {
-      citations.add(createCitation(data, dwc));
+      var citation = createCitation(data, dwc);
+      if (!Objects.equals(citation, EMTPY_CITATION)) {
+        citations.add(citation);
+      }
     }
     return citations;
   }


### PR DESCRIPTION
This is to ensure it does not just add an empty Object with only the constant `@type` field. This cleans up a bit of empty information which only bloats the object further