### PR TITLE
Bug fix/associated media pipeline

### DIFF
--- a/src/main/java/eu/dissco/core/translator/configuration/SpringCacheConfig.java
+++ b/src/main/java/eu/dissco/core/translator/configuration/SpringCacheConfig.java
@@ -1,0 +1,17 @@
+package eu.dissco.core.translator.configuration;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class SpringCacheConfig {
+
+  @Bean
+  public CacheManager cacheManager() {
+    return new ConcurrentMapCacheManager("ror", "wikidata");
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/service/CacheEvictionService.java
+++ b/src/main/java/eu/dissco/core/translator/service/CacheEvictionService.java
@@ -1,0 +1,24 @@
+package eu.dissco.core.translator.service;
+
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CacheEvictionService {
+
+  private final CacheManager cacheManager;
+
+  @Scheduled(fixedRateString = "43200000")
+  public void evictAllCaches() {
+    log.info("Evicting all caches");
+    cacheManager.getCacheNames()
+        .forEach(cacheName -> Objects.requireNonNull(cacheManager.getCache(cacheName)).clear());
+  }
+
+}

--- a/src/main/java/eu/dissco/core/translator/service/DwcaService.java
+++ b/src/main/java/eu/dissco/core/translator/service/DwcaService.java
@@ -22,7 +22,9 @@ import eu.dissco.core.translator.properties.DwcaProperties;
 import eu.dissco.core.translator.properties.EnrichmentProperties;
 import eu.dissco.core.translator.properties.FdoProperties;
 import eu.dissco.core.translator.repository.DwcaRepository;
+import eu.dissco.core.translator.schema.DigitalMedia;
 import eu.dissco.core.translator.terms.BaseDigitalObjectDirector;
+import eu.dissco.core.translator.terms.specimen.IsKnownToContainMedia;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -263,7 +265,7 @@ public class DwcaService extends WebClientService {
   private List<DigitalMediaEvent> processMedia(String recordId, JsonNode fullDigitalSpecimen,
       String organisationId) throws OrganisationException {
     var extensions = fullDigitalSpecimen.get(EXTENSIONS);
-    if (extensions != null) {
+    if (extensions != null && !extensions.equals(mapper.createObjectNode())) {
       if (extensions.get(AC_MULTIMEDIA) != null) {
         var imageArray = extensions.get(AC_MULTIMEDIA);
         addDatasetMetadata(imageArray, fullDigitalSpecimen);
@@ -332,7 +334,7 @@ public class DwcaService extends WebClientService {
               fdoProperties.getDigitalMediaType(),
               recordId,
               digitalSpecimenDirector.assembleDigitalMedia(true,
-                  mapper.createObjectNode().put("ac:accessUri", mediaUrl)
+                  mapper.createObjectNode().put("ac:accessURI", mediaUrl)
                       .set(EML_LICENSE, licenseNode),
                   organisationId),
               null));

--- a/src/main/java/eu/dissco/core/translator/service/DwcaService.java
+++ b/src/main/java/eu/dissco/core/translator/service/DwcaService.java
@@ -265,7 +265,7 @@ public class DwcaService extends WebClientService {
   private List<DigitalMediaEvent> processMedia(String recordId, JsonNode fullDigitalSpecimen,
       String organisationId) throws OrganisationException {
     var extensions = fullDigitalSpecimen.get(EXTENSIONS);
-    if (extensions != null && !extensions.equals(mapper.createObjectNode())) {
+    if (extensions != null) {
       if (extensions.get(AC_MULTIMEDIA) != null) {
         var imageArray = extensions.get(AC_MULTIMEDIA);
         addDatasetMetadata(imageArray, fullDigitalSpecimen);
@@ -279,7 +279,7 @@ public class DwcaService extends WebClientService {
           return extractMultiMedia(recordId, imageArray, organisationId);
         }
       }
-    } else if (fullDigitalSpecimen.get(DWC_ASSOCIATED_MEDIA) != null) {
+    } if (fullDigitalSpecimen.get(DWC_ASSOCIATED_MEDIA) != null) {
       return publishAssociatedMedia(recordId,
           fullDigitalSpecimen.get(DWC_ASSOCIATED_MEDIA).asText(), organisationId,
           fullDigitalSpecimen.get(EML_LICENSE));

--- a/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
@@ -87,7 +87,7 @@ import eu.dissco.core.translator.terms.specimen.DatasetName;
 import eu.dissco.core.translator.terms.specimen.Disposition;
 import eu.dissco.core.translator.terms.specimen.DynamicProperties;
 import eu.dissco.core.translator.terms.specimen.InformationWithheld;
-import eu.dissco.core.translator.terms.specimen.IsKnowToContainMedia;
+import eu.dissco.core.translator.terms.specimen.IsKnownToContainMedia;
 import eu.dissco.core.translator.terms.specimen.IsMarkedAsType;
 import eu.dissco.core.translator.terms.specimen.LivingOrPreserved;
 import eu.dissco.core.translator.terms.specimen.OrganisationID;
@@ -359,7 +359,8 @@ public abstract class BaseDigitalObjectDirector {
         .withOdsPhysicalSpecimenIDType(physicalSpecimenIdTypeHarmonised)
         .withOdsOrganisationID(organisationId)
         .withOdsPhysicalSpecimenID(physicalSpecimenId)
-        .withOdsIsKnownToContainMedia(parseToBoolean(new IsKnowToContainMedia(), data, dwc))
+        .withOdsIsKnownToContainMedia(
+            parseToBoolean(new IsKnownToContainMedia(), data, dwc))
         .withOdsSourceSystemID(
             "https://hdl.handle.net/" + sourceSystemComponent.getSourceSystemID())
         .withOdsSourceSystemName(sourceSystemComponent.getSourceSystemName())

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/IsKnownToContainMedia.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/IsKnownToContainMedia.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 import java.util.List;
 
-public class IsKnowToContainMedia extends Term {
+public class IsKnownToContainMedia extends Term {
 
   public static final String TERM = ODS_PREFIX + "isKnownToContainMedia";
   private final List<String> dwcaTerms = List.of("dwc:associatedMedia");

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/IsKnownToContainMediaTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/IsKnownToContainMediaTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class IsKnowToContainMediaTest {
+class IsKnownToContainMediaTest {
 
   private static final String MEDIA_URL = "https://archimg.mnhn.lu/Collections/Collections/ZS536.JPG";
 
-  private final IsKnowToContainMedia isKnowToContainMedia = new IsKnowToContainMedia();
+  private final IsKnownToContainMedia isKnownToContainMedia = new IsKnownToContainMedia();
 
   @Test
   void testRetrieveFromDWCA() {
@@ -23,7 +23,7 @@ class IsKnowToContainMediaTest {
     unit.put("dwc:associatedMedia", MEDIA_URL);
 
     // When
-    var result = isKnowToContainMedia.retrieveFromDWCA(unit);
+    var result = isKnownToContainMedia.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo("true");
@@ -42,7 +42,7 @@ class IsKnowToContainMediaTest {
     unit.set("extensions", extensions);
 
     // When
-    var result = isKnowToContainMedia.retrieveFromDWCA(unit);
+    var result = isKnownToContainMedia.retrieveFromDWCA(unit);
 
     // Then
     assertThat(result).isEqualTo("true");
@@ -55,7 +55,7 @@ class IsKnowToContainMediaTest {
     unit.put("abcd:multiMediaObjects/multiMediaObject/0/fileURI", MEDIA_URL);
 
     // When
-    var result = isKnowToContainMedia.retrieveFromABCD(unit);
+    var result = isKnownToContainMedia.retrieveFromABCD(unit);
 
     // Then
     assertThat(result).isEqualTo("true");
@@ -68,7 +68,7 @@ class IsKnowToContainMediaTest {
     unit.put("", MEDIA_URL);
 
     // When
-    var result = isKnowToContainMedia.retrieveFromABCD(unit);
+    var result = isKnownToContainMedia.retrieveFromABCD(unit);
 
     // Then
     assertThat(result).isEqualTo("false");
@@ -77,10 +77,10 @@ class IsKnowToContainMediaTest {
   @Test
   void testGetTerm() {
     // When
-    var result = isKnowToContainMedia.getTerm();
+    var result = isKnownToContainMedia.getTerm();
 
     // Then
-    assertThat(result).isEqualTo(IsKnowToContainMedia.TERM);
+    assertThat(result).isEqualTo(IsKnownToContainMedia.TERM);
   }
 
 }


### PR DESCRIPTION
**Caching**

A call to the ror endpoint was receiving a 422 TOO MANY REQUESTS. I wasn't entirely sure if caching was executing properly, so i introduced a cache manager like we have in the handle api. 

**Associated media**

Found a weird dataset. Instead of having extensions be null, the extensions were an empty json node. It had no data, but then the media processing wouldn't catch the associated media. This had the effect of a digital specimen with ods:isKnownToContainMedia = true, but no associated media. 

```
  private List<DigitalMediaEvent> processMedia() {
    var extensions = fullDigitalSpecimen.get(EXTENSIONS);
    if (extensions != null) {
      // use extensions to make digital media event
    } else if (fullDigitalSpecimen.get(DWC_ASSOCIATED_MEDIA) != null) {
      // use dwc:associatedMedia to make digital media event -> not called because "extensions" != null
    }
    return List.of();
  }
```
Removing the "else" catches all the weird edge cases we've yet to find :)

 