### PR TITLE
Extending dwca translation - Table naming, mapping ac:accessURI to dcterms:references

### DIFF
--- a/src/main/java/eu/dissco/core/translator/terms/media/AccessURI.java
+++ b/src/main/java/eu/dissco/core/translator/terms/media/AccessURI.java
@@ -7,7 +7,7 @@ import java.util.List;
 public class AccessURI extends Term {
 
   public static final String TERM = "ac:accessURI";
-  public static final List<String> DWCA_TERMS = List.of(TERM, "dcterms:identifier", "dc:identifier");
+  public static final List<String> DWCA_TERMS = List.of(TERM, "dcterms:identifier", "dc:identifier", "dcterms:references");
   private final List<String> abcdTerms = List.of("abcd:fileURI");
 
   @Override

--- a/src/test/java/eu/dissco/core/translator/service/DwcaServiceTest.java
+++ b/src/test/java/eu/dissco/core/translator/service/DwcaServiceTest.java
@@ -228,9 +228,9 @@ class DwcaServiceTest {
     var expected = new TranslatorJobResult(JobState.COMPLETED, 19);
     givenDWCA("/dwca-kew-gbif-media.zip");
     given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(19));
-    given(dwcaRepository.getRecords(anyList(), eq("temp_gw0_tyl_yru_identification"))).willReturn(
+    given(dwcaRepository.getRecords(anyList(), eq("temp_extension_gw0_tyl_yru_identification"))).willReturn(
         Map.of());
-    given(dwcaRepository.getRecords(anyList(), eq("temp_gw0_tyl_yru_multimedia"))).willReturn(
+    given(dwcaRepository.getRecords(anyList(), eq("temp_extension_gw0_tyl_yru_multimedia"))).willReturn(
         givenImageMap(19));
     given(digitalSpecimenDirector.assembleDigitalSpecimenTerm(any(JsonNode.class), anyBoolean()))
         .willReturn(givenDigitalSpecimen());
@@ -269,7 +269,7 @@ class DwcaServiceTest {
     givenDWCA("/dwca-naturalis-ac-media.zip");
     given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(14));
     given(dwcaRepository.getRecords(anyList(),
-        eq("temp_gw0_tyl_yru_multimedia"))).willReturn(givenImageMap(14));
+        eq("temp_extension_gw0_tyl_yru_multimedia"))).willReturn(givenImageMap(14));
     given(digitalSpecimenDirector.assembleDigitalSpecimenTerm(any(JsonNode.class), anyBoolean()))
         .willReturn(givenDigitalSpecimen());
     given(digitalSpecimenDirector.assembleDigitalMedia(anyBoolean(), any(JsonNode.class),
@@ -296,7 +296,7 @@ class DwcaServiceTest {
     givenDWCA("/dwca-invalid-ac-media.zip");
     given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(1));
     given(dwcaRepository.getRecords(anyList(),
-        eq("temp_gw0_tyl_yru_multimedia"))).willReturn(givenImageMap(1));
+        eq("temp_extension_gw0_tyl_yru_multimedia"))).willReturn(givenImageMap(1));
     given(digitalSpecimenDirector.assembleDigitalSpecimenTerm(any(JsonNode.class), anyBoolean()))
         .willReturn(givenDigitalSpecimen());
     given(digitalSpecimenDirector.assembleDigitalMedia(anyBoolean(), any(JsonNode.class),


### PR DESCRIPTION
- Table name: now includes if the table is for an extension or a code, this prevents duplicate table names
- dcterms:reference can now be mapped to ac:accessURI for media objects
- Adds "PRESERVED_SPECIMEN" to valid basisOfRecord