### PR TITLE
Add Extended Measurement Or Fact

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,0 +1,3 @@
+# July 7 2025
+# Issue with jackson-core, spring-parent update should fix this
+CVE-2025-52999

--- a/src/main/java/eu/dissco/core/translator/domain/AgentRoleType.java
+++ b/src/main/java/eu/dissco/core/translator/domain/AgentRoleType.java
@@ -8,6 +8,7 @@ public enum AgentRoleType {
   COLLECTOR("collector"),
   DATA_TRANSLATOR("data-translator"),
   CREATOR("creator"),
+  MEASURER("measurer"),
   IDENTIFIER("identifier"),
   GEOREFERENCER("georeferencer"),
   RIGHTS_OWNER("rights-owner"),

--- a/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/BaseDigitalObjectDirector.java
@@ -637,7 +637,7 @@ public abstract class BaseDigitalObjectDirector {
     if (!Objects.equals(geologicalContext, EMPTY_GEOLOGICAL_CONTEXT)) {
       location.setOdsHasGeologicalContext(geologicalContext);
     }
-    var assertions = new EventAssertions().gatherEventAssertions(mapper, data, dwc);
+    var assertions = new EventAssertions().gatherEventAssertions(termMapper, mapper, data, dwc);
     var event = new Event()
         .withType("ods:Event")
         .withDwcEventType(termMapper.retrieveTerm(new EventType(), data, dwc))

--- a/src/main/java/eu/dissco/core/translator/terms/DwcaDigitalObjectDirector.java
+++ b/src/main/java/eu/dissco/core/translator/terms/DwcaDigitalObjectDirector.java
@@ -44,6 +44,7 @@ public class DwcaDigitalObjectDirector extends BaseDigitalObjectDirector {
     list.add("dwc:otherCatalogNumbers");
     list.add("dcterms:identifier");
     list.add("dwc:materialEntityID");
+    list.add("http://rs.tdwg.org/dwc/terms/materialEntityID");
     return list;
   }
 

--- a/src/main/java/eu/dissco/core/translator/terms/Term.java
+++ b/src/main/java/eu/dissco/core/translator/terms/Term.java
@@ -70,7 +70,7 @@ public abstract class Term {
 
   protected JsonNode getSubJsonAbcd(ObjectMapper mapper, JsonNode data, int count, String path) {
     var subNode = mapper.createObjectNode();
-    data.fields().forEachRemaining(field -> {
+    data.properties().forEach(field -> {
       if (field.getKey().startsWith(path + count)) {
         subNode.set(
             field.getKey().replace(path + count + "/", ""),

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementAccuracy.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementAccuracy.java
@@ -1,0 +1,27 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class MeasurementAccuracy extends Term {
+  public static final String TERM = "dwc:measurementAccuracy";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  private final List<String> abcdTerms = List.of("measurementOrFactAtomised/accuracy");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementDeterminedDate.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementDeterminedDate.java
@@ -1,0 +1,28 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class MeasurementDeterminedDate extends Term {
+  public static final String TERM = "dwc:measurementDeterminedDate";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  private final List<String> abcdTerms = List.of("measurementOrFactAtomised/measurementDateTime");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementID.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementID.java
@@ -1,0 +1,21 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class MeasurementID extends Term {
+  public static final String TERM = "dwc:measurementID";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementMethod.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementMethod.java
@@ -1,0 +1,21 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class MeasurementMethod extends Term {
+  public static final String TERM = "dwc:measurementMethod";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementRemarks.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementRemarks.java
@@ -1,0 +1,28 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class MeasurementRemarks extends Term {
+  public static final String TERM = "dwc:measurementRemarks";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  private final List<String> abcdTerms = List.of("measurementOrFactText/value");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementType.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementType.java
@@ -1,0 +1,28 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class MeasurementType extends Term {
+  public static final String TERM = "dwc:measurementType";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  private final List<String> abcdTerms = List.of("measurementOrFactAtomised/parameter/value");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementTypeIRI.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementTypeIRI.java
@@ -1,0 +1,23 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class MeasurementTypeIRI extends Term {
+
+  public static final String TERM = "dwciri:measurementTypeID";
+
+  private final List<String> dwcaTerms = List.of(
+      "http://rs.iobis.org/obis/terms/measurementTypeID");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementUnit.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementUnit.java
@@ -1,0 +1,28 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class MeasurementUnit extends Term {
+  public static final String TERM = "dwc:measurementUnit";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  private final List<String> abcdTerms = List.of("measurementOrFactAtomised/unitOfMeasurement");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementUnitIRI.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementUnitIRI.java
@@ -1,0 +1,23 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class MeasurementUnitIRI extends Term {
+
+  public static final String TERM = "dwciri:measurementUnit";
+
+  private final List<String> dwcaTerms = List.of(
+      "http://rs.iobis.org/obis/terms/measurementUnitID");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementValue.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementValue.java
@@ -1,0 +1,28 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class MeasurementValue extends Term {
+  public static final String TERM = "dwc:measurementValue";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  private final List<String> abcdTerms = List.of("measurementOrFactAtomised/lowerValue", "measurementOrFactAtomised/upperValue");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String retrieveFromABCD(JsonNode unit) {
+    return super.searchJsonForTerm(unit, abcdTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementValueIRI.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementValueIRI.java
@@ -1,0 +1,23 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class MeasurementValueIRI extends Term {
+
+  public static final String TERM = "dwciri:measurementValueID";
+
+  private final List<String> dwcaTerms = List.of(
+      "http://rs.iobis.org/obis/terms/measurementValueID");
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/ParentMeasurementID.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/assertion/ParentMeasurementID.java
@@ -1,0 +1,21 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import java.util.List;
+
+public class ParentMeasurementID extends Term {
+  public static final String TERM = "dwc:parentMeasurementID";
+
+  private final List<String> dwcaTerms = List.of(TERM);
+
+  @Override
+  public String retrieveFromDWCA(JsonNode unit) {
+    return super.searchJsonForTerm(unit, dwcaTerms);
+  }
+
+  @Override
+  public String getTerm() {
+    return TERM;
+  }
+}

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/event/EventAssertions.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/event/EventAssertions.java
@@ -75,20 +75,21 @@ public class EventAssertions extends Term {
     var assertions = new ArrayList<Assertion>();
     if (data.get(EXTENSIONS) != null) {
       if (data.get(EXTENSIONS).get("dwc:MeasurementOrFact") != null) {
-        var measurementOrFactExtension = data.get(EXTENSIONS).get("dwc:MeasurementOrFact");
-        mapMeasurementOrFact(measurementOrFactExtension, assertions);
+        var measurementOrFact = data.get(EXTENSIONS).get("dwc:MeasurementOrFact");
+        mapMeasurementOrFact(measurementOrFact, assertions);
       }
       if (data.get(EXTENSIONS).get("http://rs.iobis.org/obis/terms/ExtendedMeasurementOrFact")
           != null) {
-        var eventAssertionsExtension = data.get(EXTENSIONS).get("http://rs.iobis.org/obis/terms/ExtendedMeasurementOrFact");
-        mapMeasurementOrFact(eventAssertionsExtension, assertions);
+        var extendedMeasurementOrFact = data.get(EXTENSIONS)
+            .get("http://rs.iobis.org/obis/terms/ExtendedMeasurementOrFact");
+        mapMeasurementOrFact(extendedMeasurementOrFact, assertions);
       }
     }
     return assertions;
   }
 
   private void mapMeasurementOrFact(JsonNode measurementOrFactExtension,
-      ArrayList<Assertion> assertions) {
+      List<Assertion> assertions) {
     for (var jsonNode : measurementOrFactExtension) {
       var assertion = new Assertion()
           .withType("ods:Assertion")
@@ -110,8 +111,6 @@ public class EventAssertions extends Term {
           .withDwciriMeasurementValue(
               super.searchJsonForTerm(jsonNode,
                   List.of("http://rs.iobis.org/obis/terms/measurementValueID")))
-          .withDwcMeasurementValue(
-              super.searchJsonForTerm(jsonNode, List.of("dwc:measurementValue")))
           .withDwcMeasurementAccuracy(
               super.searchJsonForTerm(jsonNode, List.of("dwc:measurementAccuracy")))
           .withDwcMeasurementDeterminedDate(

--- a/src/test/java/eu/dissco/core/translator/TestUtils.java
+++ b/src/test/java/eu/dissco/core/translator/TestUtils.java
@@ -16,6 +16,7 @@ import org.springframework.core.io.ClassPathResource;
 public class TestUtils {
 
   public static final ObjectMapper MAPPER = new ObjectMapper().findAndRegisterModules();
+  public static final String SOME_VALUE = "someValue";
   public static final String SOURCE_SYSTEM_ID = "20.5000.1025/GW0-TYL-YRU";
   public static final String SOURCE_SYSTEM_NAME = "Naturalis Biodiversity Center (NL) - Vermes";
   public static final String ENDPOINT = "https://data.rbge.org.uk/service/dwca/data/darwin_core_living.zip";

--- a/src/test/java/eu/dissco/core/translator/terms/media/MediaAssertionsTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/media/MediaAssertionsTest.java
@@ -27,7 +27,6 @@ class MediaAssertionsTest {
   @Test
   void testRetrieveFromABCD() {
     // Given
-    var formatString = "SpecimenName";
     var unit = MAPPER.createObjectNode();
     unit.put("abcd:fileSize", "38");
     unit.put("abcd:imageSize/width", "500");

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/OrganismScopeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/OrganismScopeTest.java
@@ -10,20 +10,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class OrganismScopeTest {
 
-  private static final String ORGANISM_Scope_STRING = "colony";
+  private static final String ORGANISM_SCOPE_STRING = "colony";
   private final OrganismScope organismScope = new OrganismScope();
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var unit = MAPPER.createObjectNode();
-    unit.put("dwc:organismScope", ORGANISM_Scope_STRING);
+    unit.put("dwc:organismScope", ORGANISM_SCOPE_STRING);
 
     // When
     var result = organismScope.retrieveFromDWCA(unit);
 
     // Then
-    assertThat(result).isEqualTo(ORGANISM_Scope_STRING);
+    assertThat(result).isEqualTo(ORGANISM_SCOPE_STRING);
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementAccuracyTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementAccuracyTest.java
@@ -1,0 +1,51 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MeasurementAccuracyTest {
+
+  private final MeasurementAccuracy measurementAccuracy = new MeasurementAccuracy();
+
+  private final String measurementAccuracyString = "0.01";
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("dwc:measurementAccuracy", measurementAccuracyString);
+
+    // When
+    var result = measurementAccuracy.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementAccuracyString);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("measurementOrFactAtomised/accuracy", measurementAccuracyString);
+
+    // When
+    var result = measurementAccuracy.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementAccuracyString);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = measurementAccuracy.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MeasurementAccuracy.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementDeterminedDateTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementDeterminedDateTest.java
@@ -1,0 +1,51 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MeasurementDeterminedDateTest {
+
+  private final MeasurementDeterminedDate measurementDeterminedDate = new MeasurementDeterminedDate();
+
+  private final String measurementDeterminedDateString = "09-10-2023T12:00:00Z";
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("dwc:measurementDeterminedDate", measurementDeterminedDateString);
+
+    // When
+    var result = measurementDeterminedDate.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementDeterminedDateString);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("measurementOrFactAtomised/measurementDateTime", measurementDeterminedDateString);
+
+    // When
+    var result = measurementDeterminedDate.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementDeterminedDateString);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = measurementDeterminedDate.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MeasurementDeterminedDate.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementIDTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementIDTest.java
@@ -1,0 +1,38 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MeasurementIDTest {
+
+  private final MeasurementID measurementID = new MeasurementID();
+
+  private final String measurementIDString = "9c752d22-b09a-11e8-96f8-529269fb1459";
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("dwc:measurementID", measurementIDString);
+
+    // When
+    var result = measurementID.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementIDString);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = measurementID.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MeasurementID.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementMethodTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementMethodTest.java
@@ -1,0 +1,38 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MeasurementMethodTest {
+
+  private final MeasurementMethod measurementMethod = new MeasurementMethod();
+
+  private final String measurementMethodString = "barometric altimeter";
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("dwc:measurementMethod", measurementMethodString);
+
+    // When
+    var result = measurementMethod.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementMethodString);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = measurementMethod.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MeasurementMethod.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementRemarksTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementRemarksTest.java
@@ -1,0 +1,51 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MeasurementRemarksTest {
+
+  private final MeasurementRemarks measurementRemarks = new MeasurementRemarks();
+
+  private final String measurementRemarksString = "tip of tail missing";
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("dwc:measurementRemarks", measurementRemarksString);
+
+    // When
+    var result = measurementRemarks.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementRemarksString);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("measurementOrFactText/value", measurementRemarksString);
+
+    // When
+    var result = measurementRemarks.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementRemarksString);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = measurementRemarks.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MeasurementRemarks.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementTypeIRITest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementTypeIRITest.java
@@ -1,0 +1,38 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MeasurementTypeIRITest {
+
+  private final MeasurementTypeIRI measurementType = new MeasurementTypeIRI();
+
+  private final String measurementTypeIRIString = "vocab.nerc.ac.uk/collection/P01/current/OCOUNT01";
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("http://rs.iobis.org/obis/terms/measurementTypeID", measurementTypeIRIString);
+
+    // When
+    var result = measurementType.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementTypeIRIString);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = measurementType.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MeasurementTypeIRI.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementTypeTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementTypeTest.java
@@ -1,0 +1,51 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MeasurementTypeTest {
+
+  private final MeasurementType measurementType = new MeasurementType();
+
+  private final String measurementTypeString = "temperature";
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("dwc:measurementType", measurementTypeString);
+
+    // When
+    var result = measurementType.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementTypeString);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("measurementOrFactAtomised/parameter/value", measurementTypeString);
+
+    // When
+    var result = measurementType.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementTypeString);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = measurementType.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MeasurementType.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementUnitIRITest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementUnitIRITest.java
@@ -1,0 +1,38 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MeasurementUnitIRITest {
+
+  private final MeasurementUnitIRI measurementUnitIRI = new MeasurementUnitIRI();
+
+  private final String measurementUnitIRIString = "http://vocab.nerc.ac.uk/collection/P06/current/ULAA/";
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("http://rs.iobis.org/obis/terms/measurementUnitID", measurementUnitIRIString);
+
+    // When
+    var result = measurementUnitIRI.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementUnitIRIString);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = measurementUnitIRI.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MeasurementUnitIRI.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementUnitTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementUnitTest.java
@@ -1,0 +1,51 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MeasurementUnitTest {
+
+  private final MeasurementUnit measurementUnit = new MeasurementUnit();
+
+  private final String measurementUnitString = "g";
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("dwc:measurementUnit", measurementUnitString);
+
+    // When
+    var result = measurementUnit.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementUnitString);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("measurementOrFactAtomised/unitOfMeasurement", measurementUnitString);
+
+    // When
+    var result = measurementUnit.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementUnitString);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = measurementUnit.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MeasurementUnit.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementValueIRITest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementValueIRITest.java
@@ -1,0 +1,38 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MeasurementValueIRITest {
+
+  private final MeasurementValueIRI measurementValueIRI = new MeasurementValueIRI();
+
+  private final String measurementValueIRIString = "http://vocab.nerc.ac.uk/collection/S11/current/S1152";
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("http://rs.iobis.org/obis/terms/measurementValueID", measurementValueIRIString);
+
+    // When
+    var result = measurementValueIRI.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementValueIRIString);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = measurementValueIRI.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MeasurementValueIRI.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementValueTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/MeasurementValueTest.java
@@ -1,0 +1,51 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MeasurementValueTest {
+
+  private final MeasurementValue measurementValue = new MeasurementValue();
+
+  private final String measurementValueString = "45";
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("dwc:measurementValue", measurementValueString);
+
+    // When
+    var result = measurementValue.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementValueString);
+  }
+
+  @Test
+  void testRetrieveFromABCD() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("measurementOrFactAtomised/upperValue", measurementValueString);
+
+    // When
+    var result = measurementValue.retrieveFromABCD(unit);
+
+    // Then
+    assertThat(result).isEqualTo(measurementValueString);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = measurementValue.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(MeasurementValue.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/ParentMeasurementIDTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/assertion/ParentMeasurementIDTest.java
@@ -1,0 +1,38 @@
+package eu.dissco.core.translator.terms.specimen.assertion;
+
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ParentMeasurementIDTest {
+
+  private final ParentMeasurementID parentMeasurementID = new ParentMeasurementID();
+
+  private final String parentMeasurementIDString = "9c752d22-b09a-11e8-96f8-529269fb1459";
+
+  @Test
+  void testRetrieveFromDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    unit.put("dwc:parentMeasurementID", parentMeasurementIDString);
+
+    // When
+    var result = parentMeasurementID.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isEqualTo(parentMeasurementIDString);
+  }
+
+  @Test
+  void testGetTerm() {
+    // When
+    var result = parentMeasurementID.getTerm();
+
+    // Then
+    assertThat(result).isEqualTo(ParentMeasurementID.TERM);
+  }
+}

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/event/EventAssertionsTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/event/EventAssertionsTest.java
@@ -51,6 +51,38 @@ class EventAssertionsTest {
   }
 
   @Test
+  void testRetrieveFromExtendedDWCA() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+    var extensions = MAPPER.createObjectNode();
+    var measurementOrFacts = MAPPER.createArrayNode();
+    var measurementOrFact = MAPPER.createObjectNode();
+    measurementOrFact.put("dwc:measurementUnit", "sex");
+    measurementOrFact.put("http://rs.iobis.org/obis/terms/measurementUnitID",
+        "vocab.nerc.ac.uk/collection/P01/current/ENTSEX01");
+    measurementOrFact.put("dwc:measurementValue", "female");
+    measurementOrFact.put("http://rs.iobis.org/obis/terms/measurementValueID",
+        "http://vocab.nerc.ac.uk/collection/S10/current/S102");
+    measurementOrFacts.add(measurementOrFact);
+    extensions.set("http://rs.iobis.org/obis/terms/ExtendedMeasurementOrFact", measurementOrFacts);
+    unit.set("extensions", extensions);
+
+    var expected = new eu.dissco.core.translator.schema.Assertion()
+        .withType("ods:Assertion")
+        .withDwcMeasurementUnit("sex")
+        .withDwciriMeasurementUnit("vocab.nerc.ac.uk/collection/P01/current/ENTSEX01")
+        .withDwcMeasurementValue("female")
+        .withDwciriMeasurementValue("http://vocab.nerc.ac.uk/collection/S10/current/S102");
+
+    // When
+    var result = eventAssertions.gatherEventAssertions(MAPPER, unit, true);
+
+    // Then
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0)).isEqualTo(expected);
+  }
+
+  @Test
   void testRetrieveFromABCD() {
     // Given
     var unit = MAPPER.createObjectNode();

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/event/EventAssertionsTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/event/EventAssertionsTest.java
@@ -2,13 +2,18 @@ package eu.dissco.core.translator.terms.specimen.event;
 
 import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static eu.dissco.core.translator.TestUtils.MOCK_DATE;
+import static eu.dissco.core.translator.TestUtils.SOME_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 
-import eu.dissco.core.translator.schema.Agent.Type;
-import eu.dissco.core.translator.schema.OdsHasRole;
-import java.util.List;
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.core.translator.terms.Term;
+import eu.dissco.core.translator.terms.TermMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -20,6 +25,8 @@ class EventAssertionsTest {
   private static final String VALUE = "2.5";
   private static final String REMARK = "Measurement of the full length10";
   private final EventAssertions eventAssertions = new EventAssertions();
+  @Mock
+  private TermMapper termMapper;
 
   @Test
   void testRetrieveFromDWCA() {
@@ -35,19 +42,14 @@ class EventAssertionsTest {
     measurementOrFacts.add(measurementOrFact);
     extensions.set("dwc:MeasurementOrFact", measurementOrFacts);
     unit.set("extensions", extensions);
+    given(termMapper.retrieveTerm(any(Term.class), eq(measurementOrFact), eq(true))).willReturn(
+        SOME_VALUE);
 
-    var expected = new eu.dissco.core.translator.schema.Assertion()
-        .withType("ods:Assertion")
-        .withDwcMeasurementUnit(UNIT)
-        .withDwcMeasurementType(TYPE)
-        .withDwcMeasurementValue(VALUE)
-        .withDwcMeasurementRemarks(REMARK);
     // When
-    var result = eventAssertions.gatherEventAssertions(MAPPER, unit, true);
+    var result = eventAssertions.gatherEventAssertions(termMapper, MAPPER, unit, true);
 
     // Then
     assertThat(result).hasSize(1);
-    assertThat(result.get(0)).isEqualTo(expected);
   }
 
   @Test
@@ -66,20 +68,14 @@ class EventAssertionsTest {
     measurementOrFacts.add(measurementOrFact);
     extensions.set("http://rs.iobis.org/obis/terms/ExtendedMeasurementOrFact", measurementOrFacts);
     unit.set("extensions", extensions);
-
-    var expected = new eu.dissco.core.translator.schema.Assertion()
-        .withType("ods:Assertion")
-        .withDwcMeasurementUnit("sex")
-        .withDwciriMeasurementUnit("vocab.nerc.ac.uk/collection/P01/current/ENTSEX01")
-        .withDwcMeasurementValue("female")
-        .withDwciriMeasurementValue("http://vocab.nerc.ac.uk/collection/S10/current/S102");
+    given(termMapper.retrieveTerm(any(Term.class), eq(measurementOrFact), eq(true))).willReturn(
+        SOME_VALUE);
 
     // When
-    var result = eventAssertions.gatherEventAssertions(MAPPER, unit, true);
+    var result = eventAssertions.gatherEventAssertions(termMapper, MAPPER, unit, true);
 
     // Then
     assertThat(result).hasSize(1);
-    assertThat(result.get(0)).isEqualTo(expected);
   }
 
   @Test
@@ -100,24 +96,13 @@ class EventAssertionsTest {
     unit.put(
         "abcd:measurementsOrFacts/measurementOrFact/0/measurementOrFactAtomised/MeasurementDateTime",
         MOCK_DATE);
+    given(termMapper.retrieveTerm(any(Term.class), any(JsonNode.class), eq(false))).willReturn(
+        SOME_VALUE);
 
-    var expected = new eu.dissco.core.translator.schema.Assertion()
-        .withType("ods:Assertion")
-        .withDwcMeasurementUnit(UNIT)
-        .withDwcMeasurementType(TYPE)
-        .withDwcMeasurementValue(VALUE)
-        .withOdsHasAgents(List.of(
-            new eu.dissco.core.translator.schema.Agent()
-                .withType(Type.SCHEMA_PERSON)
-                .withSchemaName(MEASURED_BY)
-                .withOdsHasRoles(List.of(new OdsHasRole().withSchemaRoleName("measurer")))))
-        .withDwcMeasurementDeterminedDate(MOCK_DATE)
-        .withDwcMeasurementRemarks(REMARK);
     // When
-    var result = eventAssertions.gatherEventAssertions(MAPPER, unit, false);
+    var result = eventAssertions.gatherEventAssertions(termMapper, MAPPER, unit, false);
 
     // Then
     assertThat(result).hasSize(1);
-    assertThat(result.get(0)).isEqualTo(expected);
   }
 }

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/identification/IdentificationQualifierTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/identification/IdentificationQualifierTest.java
@@ -11,19 +11,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class IdentificationQualifierTest {
 
   private final IdentificationQualifier identificationQualifier = new IdentificationQualifier();
-  private final String IdentificationQualifierString = "cf. var. oxyadenia";
+  private final String identificationQualifierString = "cf. var. oxyadenia";
 
   @Test
   void testRetrieveFromDWCA() {
     // Given
     var unit = MAPPER.createObjectNode();
-    unit.put("dwc:identificationQualifier", IdentificationQualifierString);
+    unit.put("dwc:identificationQualifier", identificationQualifierString);
 
     // When
     var result = identificationQualifier.retrieveFromDWCA(unit);
 
     // Then
-    assertThat(result).isEqualTo(IdentificationQualifierString);
+    assertThat(result).isEqualTo(identificationQualifierString);
   }
 
   @Test
@@ -31,13 +31,13 @@ class IdentificationQualifierTest {
     // Given
     var unit = MAPPER.createObjectNode();
     unit.put("result/taxonIdentified/scientificName/identificationQualifier/nameAddendum",
-        IdentificationQualifierString);
+        identificationQualifierString);
 
     // When
     var result = identificationQualifier.retrieveFromABCD(unit);
 
     // Then
-    assertThat(result).isEqualTo(IdentificationQualifierString);
+    assertThat(result).isEqualTo(identificationQualifierString);
   }
 
   @Test


### PR DESCRIPTION
Add DWCA extendedMeasurementOrFact.
This maps to an event assertion, not sure if this is correct, but that is how we were doing the regular MeasurementOrFact.
Added support for materialEntityID to add it to the ID's (needs full name as it isn't a Term yet).
In the test data, there was already a RBINS set that uses this.