### PR TITLE
Generate report and add to the translator job record

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -8,11 +8,20 @@ CVE-2026-33416
 
 # March 2, 2026
 # Issue with alpine image, libpng
-CVE-2026-33636 
+CVE-2026-33636
 
 # March 10, 2026
 # Issue with alpine image, zlib: zlib: Arbitrary code execution via buffer overflow
 CVE-2026-22184
+
+# April 15 2026
+# Issue with alpine image, openssl, libcrypto3, libssl3: Denial of Service due to NULL pointer
+CVE-2026-28390
+
+# April 15 2026
+# Issue with alpine image, musl: musl libc: Arbitrary code execution and denial of service
+CVE-2026-40200
+
 
 # July 7 2025
 # Issue with jackson-core, gbif-common would need an update for this
@@ -21,3 +30,7 @@ CVE-2025-52999
 # April 3 2026
 # Issue with org.codehaus.plexus:plexus-utils, jaxb maven plugin needs to be updated
 CVE-2025-67030
+
+# April 15 2026
+# Issue with tools.jackson.core:jackson-core, spring boot update should fix this
+GHSA-2m67-wjpj-xhg9

--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,24 +1,23 @@
-# July 7 2025
-# Issue with jackson-core, gbif-common would need an update for this
-CVE-2025-52999
-
 # March 2, 2026
 # Issue with alpine image, libpng
 CVE-2026-25646
+
+# March 2, 2026
+# Issue with alpine image, libpng
+CVE-2026-33416
+
+# March 2, 2026
+# Issue with alpine image, libpng
+CVE-2026-33636 
 
 # March 10, 2026
 # Issue with alpine image, zlib: zlib: Arbitrary code execution via buffer overflow
 CVE-2026-22184
 
-# March 2, 2026
-# Issue with jackson, spring boot may need to update its jackson 2 version
-# Also could be fixed by upgrading to jackson 3
-GHSA-72hv-8253-57qq
+# July 7 2025
+# Issue with jackson-core, gbif-common would need an update for this
+CVE-2025-52999
 
-# March 6, 2026
-# jackson-core has Nesting Depth Constraint Bypass, jackson should be fixed to 3.1.X
-CVE-2026-29062
-
-# March 20, 2026
-# Issue with libexpat, alpine image needs to update
-CVE-2026-32767
+# April 3 2026
+# Issue with org.codehaus.plexus:plexus-utils, jaxb maven plugin needs to be updated
+CVE-2025-67030

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.5</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>
@@ -18,12 +18,12 @@
     <java.version>25</java.version>
     <dwca-io.version>3.0.0</dwca-io.version>
     <commons-beanutils.version>1.11.0</commons-beanutils.version>
-    <jaxb2-maven-plugin.version>3.3.0</jaxb2-maven-plugin.version>
+    <jaxb2-maven-plugin.version>4.1.0</jaxb2-maven-plugin.version>
     <commons-compress.version>1.28.0</commons-compress.version>
     <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
     <jakarta.xml.bind-api.version>4.0.5</jakarta.xml.bind-api.version>
+    <spring-format.version>0.0.47</spring-format.version>
     <mockito-core.version>5.21.0</mockito-core.version>
-    <testcontainers.version>1.21.4</testcontainers.version>
     <sonar.organization>dissco</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.coverage.jacoco.xmlReportPaths>../app-it/target/site/jacoco-aggregate/jacoco.xml
@@ -153,17 +153,17 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
+      <artifactId>testcontainers-postgresql</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>rabbitmq</artifactId>
+      <artifactId>testcontainers-rabbitmq</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -311,6 +311,11 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.spring.javaformat</groupId>
+        <artifactId>spring-javaformat-maven-plugin</artifactId>
+        <version>${spring-format.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/eu/dissco/core/translator/component/OrganisationNameComponent.java
+++ b/src/main/java/eu/dissco/core/translator/component/OrganisationNameComponent.java
@@ -7,9 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.json.JsonMapper;
 
 @Slf4j
 @Component

--- a/src/main/java/eu/dissco/core/translator/database/jooq/Keys.java
+++ b/src/main/java/eu/dissco/core/translator/database/jooq/Keys.java
@@ -30,6 +30,7 @@ public class Keys {
 
     public static final UniqueKey<DataMappingRecord> DATA_MAPPING_PK = Internal.createUniqueKey(DataMapping.DATA_MAPPING, DSL.name("data_mapping_pk"), new TableField[] { DataMapping.DATA_MAPPING.ID, DataMapping.DATA_MAPPING.VERSION }, true);
     public static final UniqueKey<SourceSystemRecord> ENDPOINT_UNIQUE = Internal.createUniqueKey(SourceSystem.SOURCE_SYSTEM, DSL.name("endpoint_unique"), new TableField[] { SourceSystem.SOURCE_SYSTEM.ENDPOINT, SourceSystem.SOURCE_SYSTEM.TOMBSTONED, SourceSystem.SOURCE_SYSTEM.FILTERS }, true);
+    public static final UniqueKey<SourceSystemRecord> NAME_UNIQUE = Internal.createUniqueKey(SourceSystem.SOURCE_SYSTEM, DSL.name("name_unique"), new TableField[] { SourceSystem.SOURCE_SYSTEM.NAME }, true);
     public static final UniqueKey<SourceSystemRecord> SOURCE_SYSTEM_PKEY = Internal.createUniqueKey(SourceSystem.SOURCE_SYSTEM, DSL.name("source_system_pkey"), new TableField[] { SourceSystem.SOURCE_SYSTEM.ID }, true);
     public static final UniqueKey<TranslatorJobRecordRecord> TRANSLATOR_JOB_RECORD_PKEY = Internal.createUniqueKey(TranslatorJobRecord.TRANSLATOR_JOB_RECORD, DSL.name("translator_job_record_pkey"), new TableField[] { TranslatorJobRecord.TRANSLATOR_JOB_RECORD.JOB_ID, TranslatorJobRecord.TRANSLATOR_JOB_RECORD.SOURCE_SYSTEM_ID }, true);
 }

--- a/src/main/java/eu/dissco/core/translator/database/jooq/tables/SourceSystem.java
+++ b/src/main/java/eu/dissco/core/translator/database/jooq/tables/SourceSystem.java
@@ -127,7 +127,7 @@ public class SourceSystem extends TableImpl<SourceSystemRecord> {
     /**
      * The column <code>public.source_system.filters</code>.
      */
-    public final TableField<SourceSystemRecord, String> FILTERS = createField(DSL.name("filters"), SQLDataType.CLOB, this, "");
+    public final TableField<SourceSystemRecord, String[]> FILTERS = createField(DSL.name("filters"), SQLDataType.CLOB.array(), this, "");
 
     private SourceSystem(Name alias, Table<SourceSystemRecord> aliased) {
         this(alias, aliased, (Field<?>[]) null, null);
@@ -170,7 +170,7 @@ public class SourceSystem extends TableImpl<SourceSystemRecord> {
 
     @Override
     public List<UniqueKey<SourceSystemRecord>> getUniqueKeys() {
-        return Arrays.asList(Keys.ENDPOINT_UNIQUE);
+        return Arrays.asList(Keys.ENDPOINT_UNIQUE, Keys.NAME_UNIQUE);
     }
 
     @Override

--- a/src/main/java/eu/dissco/core/translator/database/jooq/tables/TranslatorJobRecord.java
+++ b/src/main/java/eu/dissco/core/translator/database/jooq/tables/TranslatorJobRecord.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 
 import org.jooq.Condition;
 import org.jooq.Field;
+import org.jooq.JSONB;
 import org.jooq.Name;
 import org.jooq.PlainSQL;
 import org.jooq.QueryPart;
@@ -87,6 +88,11 @@ public class TranslatorJobRecord extends TableImpl<TranslatorJobRecordRecord> {
      * The column <code>public.translator_job_record.error</code>.
      */
     public final TableField<TranslatorJobRecordRecord, ErrorCode> ERROR = createField(DSL.name("error"), SQLDataType.VARCHAR.asEnumDataType(ErrorCode.class), this, "");
+
+    /**
+     * The column <code>public.translator_job_record.report</code>.
+     */
+    public final TableField<TranslatorJobRecordRecord, JSONB> REPORT = createField(DSL.name("report"), SQLDataType.JSONB, this, "");
 
     private TranslatorJobRecord(Name alias, Table<TranslatorJobRecordRecord> aliased) {
         this(alias, aliased, (Field<?>[]) null, null);

--- a/src/main/java/eu/dissco/core/translator/database/jooq/tables/records/SourceSystemRecord.java
+++ b/src/main/java/eu/dissco/core/translator/database/jooq/tables/records/SourceSystemRecord.java
@@ -221,15 +221,15 @@ public class SourceSystemRecord extends UpdatableRecordImpl<SourceSystemRecord> 
     /**
      * Setter for <code>public.source_system.filters</code>.
      */
-    public void setFilters(String value) {
+    public void setFilters(String[] value) {
         set(14, value);
     }
 
     /**
      * Getter for <code>public.source_system.filters</code>.
      */
-    public String getFilters() {
-        return (String) get(14);
+    public String[] getFilters() {
+        return (String[]) get(14);
     }
 
     // -------------------------------------------------------------------------
@@ -255,7 +255,7 @@ public class SourceSystemRecord extends UpdatableRecordImpl<SourceSystemRecord> 
     /**
      * Create a detached, initialised SourceSystemRecord
      */
-    public SourceSystemRecord(String id, Integer version, String name, String endpoint, Instant created, Instant modified, Instant tombstoned, String mappingId, String creator, TranslatorType translatorType, JSONB data, String dwcDpLink, String dwcaLink, byte[] eml, String filters) {
+    public SourceSystemRecord(String id, Integer version, String name, String endpoint, Instant created, Instant modified, Instant tombstoned, String mappingId, String creator, TranslatorType translatorType, JSONB data, String dwcDpLink, String dwcaLink, byte[] eml, String[] filters) {
         super(SourceSystem.SOURCE_SYSTEM);
 
         setId(id);

--- a/src/main/java/eu/dissco/core/translator/database/jooq/tables/records/TranslatorJobRecordRecord.java
+++ b/src/main/java/eu/dissco/core/translator/database/jooq/tables/records/TranslatorJobRecordRecord.java
@@ -11,6 +11,7 @@ import eu.dissco.core.translator.database.jooq.tables.TranslatorJobRecord;
 import java.time.Instant;
 import java.util.UUID;
 
+import org.jooq.JSONB;
 import org.jooq.Record2;
 import org.jooq.impl.UpdatableRecordImpl;
 
@@ -121,6 +122,20 @@ public class TranslatorJobRecordRecord extends UpdatableRecordImpl<TranslatorJob
         return (ErrorCode) get(6);
     }
 
+    /**
+     * Setter for <code>public.translator_job_record.report</code>.
+     */
+    public void setReport(JSONB value) {
+        set(7, value);
+    }
+
+    /**
+     * Getter for <code>public.translator_job_record.report</code>.
+     */
+    public JSONB getReport() {
+        return (JSONB) get(7);
+    }
+
     // -------------------------------------------------------------------------
     // Primary key information
     // -------------------------------------------------------------------------
@@ -144,7 +159,7 @@ public class TranslatorJobRecordRecord extends UpdatableRecordImpl<TranslatorJob
     /**
      * Create a detached, initialised TranslatorJobRecordRecord
      */
-    public TranslatorJobRecordRecord(UUID jobId, JobState jobState, String sourceSystemId, Instant timeStarted, Instant timeCompleted, Integer processedRecords, ErrorCode error) {
+    public TranslatorJobRecordRecord(UUID jobId, JobState jobState, String sourceSystemId, Instant timeStarted, Instant timeCompleted, Integer processedRecords, ErrorCode error, JSONB report) {
         super(TranslatorJobRecord.TRANSLATOR_JOB_RECORD);
 
         setJobId(jobId);
@@ -154,6 +169,7 @@ public class TranslatorJobRecordRecord extends UpdatableRecordImpl<TranslatorJob
         setTimeCompleted(timeCompleted);
         setProcessedRecords(processedRecords);
         setError(error);
+        setReport(report);
         resetChangedOnNotNull();
     }
 }

--- a/src/main/java/eu/dissco/core/translator/domain/TranslatorJobReport.java
+++ b/src/main/java/eu/dissco/core/translator/domain/TranslatorJobReport.java
@@ -1,0 +1,41 @@
+package eu.dissco.core.translator.domain;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public final class TranslatorJobReport {
+
+  private final Map<String, Integer> digitalSpecimenIssues;
+  private final Map<String, Integer> digitalMediaIssues;
+  private Integer successfulSpecimen;
+  private Integer successfulMedia;
+
+  public TranslatorJobReport(Map<String, Integer> digitalSpecimenIssues,
+      Map<String, Integer> digitalMediaIssues, Integer successfulSpecimen,
+      Integer successfulMedia) {
+    this.digitalSpecimenIssues = digitalSpecimenIssues;
+    this.digitalMediaIssues = digitalMediaIssues;
+    this.successfulSpecimen = successfulSpecimen;
+    this.successfulMedia = successfulMedia;
+  }
+
+  public TranslatorJobReport() {
+    this(new HashMap<>(), new HashMap<>(), 0, 0);
+  }
+
+  public void addSpecimenIssues(String key) {
+    digitalSpecimenIssues.put(key, digitalSpecimenIssues.getOrDefault(key, 0) + 1);
+  }
+
+  public void addMediaIssues(String key) {
+    digitalMediaIssues.put(key, digitalMediaIssues.getOrDefault(key, 0) + 1);
+  }
+
+  public void incrementSuccessfulRecords(int digitalMediaCount) {
+    successfulSpecimen = successfulSpecimen + 1;
+    successfulMedia = successfulMedia + digitalMediaCount;
+  }
+
+}

--- a/src/main/java/eu/dissco/core/translator/domain/TranslatorJobReport.java
+++ b/src/main/java/eu/dissco/core/translator/domain/TranslatorJobReport.java
@@ -7,35 +7,46 @@ import lombok.Data;
 @Data
 public final class TranslatorJobReport {
 
-  private final Map<String, Integer> digitalSpecimenIssues;
-  private final Map<String, Integer> digitalMediaIssues;
-  private Integer successfulSpecimen;
-  private Integer successfulMedia;
+	private final Map<String, Integer> digitalSpecimenRejected;
 
-  public TranslatorJobReport(Map<String, Integer> digitalSpecimenIssues,
-      Map<String, Integer> digitalMediaIssues, Integer successfulSpecimen,
-      Integer successfulMedia) {
-    this.digitalSpecimenIssues = digitalSpecimenIssues;
-    this.digitalMediaIssues = digitalMediaIssues;
-    this.successfulSpecimen = successfulSpecimen;
-    this.successfulMedia = successfulMedia;
-  }
+	private final Map<String, Integer> digitalMediaRejected;
 
-  public TranslatorJobReport() {
-    this(new HashMap<>(), new HashMap<>(), 0, 0);
-  }
+	private Integer successfulSpecimen;
 
-  public void addSpecimenIssues(String key) {
-    digitalSpecimenIssues.put(key, digitalSpecimenIssues.getOrDefault(key, 0) + 1);
-  }
+	private Integer successfulMedia;
 
-  public void addMediaIssues(String key) {
-    digitalMediaIssues.put(key, digitalMediaIssues.getOrDefault(key, 0) + 1);
-  }
+	private Integer rejectedSpecimen;
 
-  public void incrementSuccessfulRecords(int digitalMediaCount) {
-    successfulSpecimen = successfulSpecimen + 1;
-    successfulMedia = successfulMedia + digitalMediaCount;
-  }
+	private Integer rejectedMedia;
+
+	public TranslatorJobReport(Map<String, Integer> digitalSpecimenIssues, Map<String, Integer> digitalMediaIssues,
+			Integer successfulSpecimen, Integer successfulMedia, Integer rejectedSpecimen, Integer rejectedMedia) {
+		this.digitalSpecimenRejected = digitalSpecimenIssues == null ? new HashMap<>()
+				: new HashMap<>(digitalSpecimenIssues);
+		this.digitalMediaRejected = digitalMediaIssues == null ? new HashMap<>() : new HashMap<>(digitalMediaIssues);
+		this.successfulSpecimen = successfulSpecimen == null ? 0 : successfulSpecimen;
+		this.successfulMedia = successfulMedia == null ? 0 : successfulMedia;
+		this.rejectedSpecimen = rejectedSpecimen == null ? 0 : rejectedSpecimen;
+		this.rejectedMedia = rejectedMedia == null ? 0 : rejectedMedia;
+	}
+
+	public TranslatorJobReport() {
+		this(new HashMap<>(), new HashMap<>(), 0, 0, 0, 0);
+	}
+
+	public void addRejectedSpecimen(String key) {
+		rejectedSpecimen = rejectedSpecimen + 1;
+		digitalSpecimenRejected.put(key, digitalSpecimenRejected.getOrDefault(key, 0) + 1);
+	}
+
+	public void addRejectedMedia(String key) {
+		rejectedMedia = rejectedMedia + 1;
+		digitalMediaRejected.put(key, digitalMediaRejected.getOrDefault(key, 0) + 1);
+	}
+
+	public void incrementSuccessfulRecords(int digitalMediaCount) {
+		successfulSpecimen = successfulSpecimen + 1;
+		successfulMedia = successfulMedia + digitalMediaCount;
+	}
 
 }

--- a/src/main/java/eu/dissco/core/translator/domain/TranslatorJobResult.java
+++ b/src/main/java/eu/dissco/core/translator/domain/TranslatorJobResult.java
@@ -4,7 +4,7 @@ import eu.dissco.core.translator.database.jooq.enums.JobState;
 
 public record TranslatorJobResult(
     JobState jobState,
-    int processedRecords
+    TranslatorJobReport report
 ) {
 
 }

--- a/src/main/java/eu/dissco/core/translator/repository/TranslatorJobRecordRepository.java
+++ b/src/main/java/eu/dissco/core/translator/repository/TranslatorJobRecordRepository.java
@@ -10,7 +10,9 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
+import org.jooq.JSONB;
 import org.springframework.stereotype.Repository;
+import tools.jackson.databind.json.JsonMapper;
 
 @Slf4j
 @Repository
@@ -18,6 +20,7 @@ import org.springframework.stereotype.Repository;
 public class TranslatorJobRecordRepository {
 
   private final DSLContext context;
+  private final JsonMapper jsonMapper;
 
   public void createNewJobRecord(UUID jobId, String sourceSystemId) {
     context.insertInto(TRANSLATOR_JOB_RECORD)
@@ -33,7 +36,8 @@ public class TranslatorJobRecordRepository {
     context.update(TRANSLATOR_JOB_RECORD)
         .set(TRANSLATOR_JOB_RECORD.JOB_STATE, processingResult.jobState())
         .set(TRANSLATOR_JOB_RECORD.TIME_COMPLETED, Instant.now())
-        .set(TRANSLATOR_JOB_RECORD.PROCESSED_RECORDS, processingResult.processedRecords())
+        .set(TRANSLATOR_JOB_RECORD.PROCESSED_RECORDS, processingResult.report().getSuccessfulSpecimen())
+        .set(TRANSLATOR_JOB_RECORD.REPORT, JSONB.valueOf(jsonMapper.writeValueAsString(processingResult.report())))
         .set(TRANSLATOR_JOB_RECORD.ERROR, errorCode)
         .where(TRANSLATOR_JOB_RECORD.JOB_ID.eq(jobId))
         .execute();

--- a/src/main/java/eu/dissco/core/translator/service/AbstractDataRetrievalService.java
+++ b/src/main/java/eu/dissco/core/translator/service/AbstractDataRetrievalService.java
@@ -16,113 +16,106 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public abstract class AbstractDataRetrievalService {
 
-  private static final String NOT_ACCEPTED = "' is not accepted";
+	private static final String NOT_ACCEPTED = "' is not accepted";
 
-  protected static final Set<String> ALLOWED_BASIS_OF_RECORD = Set.of("PRESERVEDSPECIMEN",
-      "PRESERVED_SPECIMEN", "FOSSIL", "OTHER", "ROCK", "MINERAL", "METEORITE", "FOSSILSPECIMEN",
-      "LIVINGSPECIMEN", "MATERIALSAMPLE", "ROCKSPECIMEN", "MINERALSPECIMEN", "METEORITESPECIMEN",
-      "HERBARIUMSHEET",
-      "DRIED");
+	protected static final Set<String> ALLOWED_BASIS_OF_RECORD = Set.of("PRESERVEDSPECIMEN", "PRESERVED_SPECIMEN",
+			"FOSSIL", "OTHER", "ROCK", "MINERAL", "METEORITE", "FOSSILSPECIMEN", "LIVINGSPECIMEN", "MATERIALSAMPLE",
+			"ROCKSPECIMEN", "MINERALSPECIMEN", "METEORITESPECIMEN", "HERBARIUMSHEET", "DRIED");
 
-  protected final TranslatorJobReport report;
-  private final List<Predicate<DigitalSpecimen>> specimenComplianceChecks =
-      List.of(this::isNormalisedPhysicalSpecimenIDPresent,
-          this::isOrganisationIDPresent,
-          this::basisOfRecordComplies,
-          this::digitalSpecimenLicenseComplies);
-  private final List<Predicate<DigitalMedia>> mediaComplianceChecks =
-      List.of(this::digitalMediaLicenseComplies,
-          this::isAccessURIPresent);
+	protected final TranslatorJobReport report;
 
-  public abstract TranslatorJobResult retrieveData();
+	private final List<Predicate<DigitalSpecimen>> specimenComplianceChecks = List.of(
+			this::isNormalisedPhysicalSpecimenIDPresent, this::isOrganisationIDPresent, this::basisOfRecordComplies,
+			this::digitalSpecimenLicenseComplies);
 
-  protected boolean isStartElement(XMLEvent element, String field) {
-    if (element != null) {
-      return element.isStartElement() && element.asStartElement().getName().getLocalPart()
-          .equals(field);
-    } else {
-      return false;
-    }
-  }
+	private final List<Predicate<DigitalMedia>> mediaComplianceChecks = List.of(this::digitalMediaLicenseComplies,
+			this::isAccessURIPresent);
 
-  protected void checkIfSpecimenComplies(DigitalSpecimen ds)
-      throws DiSSCoDataException {
-    for (var check : specimenComplianceChecks) {
-      if (!check.test(ds)) {
-        throw new DiSSCoDataException("Specimen with id " + ds.getOdsNormalisedPhysicalSpecimenID()
-            + " does not comply with the requirements, ignoring record");
-      }
-    }
-  }
+	public abstract TranslatorJobResult retrieveData();
 
-  private boolean digitalSpecimenLicenseComplies(DigitalSpecimen ds) {
-    var license = ds.getDctermsLicense();
-    if (!licenseComplies(license)) {
-      report.addSpecimenIssues("License '" + license + NOT_ACCEPTED);
-      return false;
-    } else {
-      return true;
-    }
-  }
+	protected boolean isStartElement(XMLEvent element, String field) {
+		if (element != null) {
+			return element.isStartElement() && element.asStartElement().getName().getLocalPart().equals(field);
+		}
+		return false;
+	}
 
-  private boolean isOrganisationIDPresent(DigitalSpecimen ds) {
-    if (ds.getOdsOrganisationID() != null) {
-      return true;
-    } else {
-      report.addSpecimenIssues("Missing Organisation ID");
-      return false;
-    }
-  }
+	protected void checkIfSpecimenComplies(DigitalSpecimen ds) throws DiSSCoDataException {
+		for (var check : specimenComplianceChecks) {
+			if (!check.test(ds)) {
+				throw new DiSSCoDataException("Specimen with id " + ds.getOdsNormalisedPhysicalSpecimenID()
+						+ " does not comply with the requirements, ignoring record");
+			}
+		}
+	}
 
-  private boolean isNormalisedPhysicalSpecimenIDPresent(DigitalSpecimen ds) {
-    if (ds.getOdsNormalisedPhysicalSpecimenID() != null) {
-      return true;
-    } else {
-      report.addSpecimenIssues("Missing Normalised Physical Specimen Identifier");
-      return false;
-    }
-  }
+	private boolean digitalSpecimenLicenseComplies(DigitalSpecimen ds) {
+		var license = ds.getDctermsLicense();
+		if (!licenseComplies(license)) {
+			report.addRejectedSpecimen("License '" + license + NOT_ACCEPTED);
+			return false;
+		}
+		return true;
+	}
 
-  private boolean basisOfRecordComplies(DigitalSpecimen ds) {
-    String basisOfRecord = ds.getDwcBasisOfRecord();
-    if (basisOfRecord == null) {
-      report.addSpecimenIssues("Missing Basis of Record");
-      return false;
-    }
-    if (ALLOWED_BASIS_OF_RECORD.contains(basisOfRecord.strip().replace(" ", "").toUpperCase())) {
-      return true;
-    } else {
-      report.addSpecimenIssues("BasisOfRecord '" + basisOfRecord + NOT_ACCEPTED);
-      return false;
-    }
-  }
+	private boolean isOrganisationIDPresent(DigitalSpecimen ds) {
+		if (ds.getOdsOrganisationID() != null) {
+			return true;
+		}
+		report.addRejectedSpecimen("Missing Organisation ID");
+		return false;
 
-  protected void checkIfMediaComplies(DigitalMedia dm)
-      throws DiSSCoDataException {
-    for (var check : mediaComplianceChecks) {
-      if (!check.test(dm)) {
-        throw new DiSSCoDataException("Media with id " + dm.getAcAccessURI()
-            + " does not comply with the requirements, ignoring record");
-      }
-    }
-  }
+	}
 
-  private boolean isAccessURIPresent(DigitalMedia dm) {
-    if (dm.getAcAccessURI() != null) {
-      return true;
-    } else {
-      report.addMediaIssues("Missing Access URI");
-      return false;
-    }
-  }
+	private boolean isNormalisedPhysicalSpecimenIDPresent(DigitalSpecimen ds) {
+		if (ds.getOdsNormalisedPhysicalSpecimenID() != null) {
+			return true;
+		}
+		report.addRejectedSpecimen("Missing Normalised Physical Specimen Identifier");
+		return false;
 
-  private boolean digitalMediaLicenseComplies(DigitalMedia dm) {
-    var license = dm.getDctermsRights();
-    if (!licenseComplies(license)) {
-      report.addMediaIssues("License '" + license + NOT_ACCEPTED);
-      return false;
-    } else {
-      return true;
-    }
-  }
+	}
+
+	private boolean basisOfRecordComplies(DigitalSpecimen ds) {
+		String basisOfRecord = ds.getDwcBasisOfRecord();
+		if (basisOfRecord == null) {
+			report.addRejectedSpecimen("Missing Basis of Record");
+			return false;
+		}
+		if (ALLOWED_BASIS_OF_RECORD.contains(basisOfRecord.strip().replace(" ", "").toUpperCase())) {
+			return true;
+		}
+		report.addRejectedSpecimen("BasisOfRecord '" + basisOfRecord + NOT_ACCEPTED);
+		return false;
+
+	}
+
+	protected void checkIfMediaComplies(DigitalMedia dm) throws DiSSCoDataException {
+		for (var check : mediaComplianceChecks) {
+			if (!check.test(dm)) {
+				throw new DiSSCoDataException("Media with id " + dm.getAcAccessURI()
+						+ " does not comply with the requirements, ignoring record");
+			}
+		}
+	}
+
+	private boolean isAccessURIPresent(DigitalMedia dm) {
+		if (dm.getAcAccessURI() != null) {
+			return true;
+		}
+		report.addRejectedMedia("Missing Access URI");
+		return false;
+
+	}
+
+	private boolean digitalMediaLicenseComplies(DigitalMedia dm) {
+		var license = dm.getDctermsRights();
+		if (!licenseComplies(license)) {
+			report.addRejectedMedia("License '" + license + NOT_ACCEPTED);
+			return false;
+		}
+		return true;
+
+	}
+
 }

--- a/src/main/java/eu/dissco/core/translator/service/AbstractDataRetrievalService.java
+++ b/src/main/java/eu/dissco/core/translator/service/AbstractDataRetrievalService.java
@@ -2,19 +2,37 @@ package eu.dissco.core.translator.service;
 
 import static eu.dissco.core.translator.terms.utils.LicenseUtils.licenseComplies;
 
+import eu.dissco.core.translator.domain.TranslatorJobReport;
 import eu.dissco.core.translator.domain.TranslatorJobResult;
 import eu.dissco.core.translator.exception.DiSSCoDataException;
-import java.util.Set;
-import javax.xml.stream.events.XMLEvent;
-import eu.dissco.core.translator.schema.DigitalSpecimen;
 import eu.dissco.core.translator.schema.DigitalMedia;
+import eu.dissco.core.translator.schema.DigitalSpecimen;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import javax.xml.stream.events.XMLEvent;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 public abstract class AbstractDataRetrievalService {
+
+  private static final String NOT_ACCEPTED = "' is not accepted";
 
   protected static final Set<String> ALLOWED_BASIS_OF_RECORD = Set.of("PRESERVEDSPECIMEN",
       "PRESERVED_SPECIMEN", "FOSSIL", "OTHER", "ROCK", "MINERAL", "METEORITE", "FOSSILSPECIMEN",
-      "LIVINGSPECIMEN", "MATERIALSAMPLE", "ROCKSPECIMEN", "MINERALSPECIMEN", "METEORITESPECIMEN", "HERBARIUMSHEET",
+      "LIVINGSPECIMEN", "MATERIALSAMPLE", "ROCKSPECIMEN", "MINERALSPECIMEN", "METEORITESPECIMEN",
+      "HERBARIUMSHEET",
       "DRIED");
+
+  protected final TranslatorJobReport report;
+  private final List<Predicate<DigitalSpecimen>> specimenComplianceChecks =
+      List.of(this::isNormalisedPhysicalSpecimenIDPresent,
+          this::isOrganisationIDPresent,
+          this::basisOfRecordComplies,
+          this::digitalSpecimenLicenseComplies);
+  private final List<Predicate<DigitalMedia>> mediaComplianceChecks =
+      List.of(this::digitalMediaLicenseComplies,
+          this::isAccessURIPresent);
 
   public abstract TranslatorJobResult retrieveData();
 
@@ -29,33 +47,82 @@ public abstract class AbstractDataRetrievalService {
 
   protected void checkIfSpecimenComplies(DigitalSpecimen ds)
       throws DiSSCoDataException {
-    if (ds.getOdsNormalisedPhysicalSpecimenID() == null || ds.getOdsOrganisationID() == null) {
-      throw new DiSSCoDataException(
-          "Record does not comply to MIDS level 0 (id and organisation), ignoring record");
-    }
-    if (!basisOfRecordComplies(ds.getDwcBasisOfRecord())
-        || !licenseComplies(ds.getDctermsLicense())) {
-      throw new DiSSCoDataException(
-          "Record does not comply with basis of record or license requirements");
+    for (var check : specimenComplianceChecks) {
+      if (!check.test(ds)) {
+        throw new DiSSCoDataException("Specimen with id " + ds.getOdsNormalisedPhysicalSpecimenID()
+            + " does not comply with the requirements, ignoring record");
+      }
     }
   }
 
-    private static boolean basisOfRecordComplies(String basisOfRecord) {
-      if (basisOfRecord == null) {
-          return false;
-      }
-      return ALLOWED_BASIS_OF_RECORD.contains(basisOfRecord.strip().replace(" ", "").toUpperCase());
+  private boolean digitalSpecimenLicenseComplies(DigitalSpecimen ds) {
+    var license = ds.getDctermsLicense();
+    if (!licenseComplies(license)) {
+      report.addSpecimenIssues("License '" + license + NOT_ACCEPTED);
+      return false;
+    } else {
+      return true;
     }
+  }
 
-    protected void checkIfMediaComplies(DigitalMedia digitalMedia)
-      throws DiSSCoDataException {
-    if (digitalMedia.getAcAccessURI() == null) {
-      throw new DiSSCoDataException(
-          "Digital media object for specimen does not have an access uri, ignoring record");
+  private boolean isOrganisationIDPresent(DigitalSpecimen ds) {
+    if (ds.getOdsOrganisationID() != null) {
+      return true;
+    } else {
+      report.addSpecimenIssues("Missing Organisation ID");
+      return false;
     }
-    if (!licenseComplies(digitalMedia.getDctermsRights())) {
-      throw new DiSSCoDataException(
-          "Digital media object does not have a valid license uri, ignoring record");
+  }
+
+  private boolean isNormalisedPhysicalSpecimenIDPresent(DigitalSpecimen ds) {
+    if (ds.getOdsNormalisedPhysicalSpecimenID() != null) {
+      return true;
+    } else {
+      report.addSpecimenIssues("Missing Normalised Physical Specimen Identifier");
+      return false;
+    }
+  }
+
+  private boolean basisOfRecordComplies(DigitalSpecimen ds) {
+    String basisOfRecord = ds.getDwcBasisOfRecord();
+    if (basisOfRecord == null) {
+      report.addSpecimenIssues("Missing Basis of Record");
+      return false;
+    }
+    if (ALLOWED_BASIS_OF_RECORD.contains(basisOfRecord.strip().replace(" ", "").toUpperCase())) {
+      return true;
+    } else {
+      report.addSpecimenIssues("BasisOfRecord '" + basisOfRecord + NOT_ACCEPTED);
+      return false;
+    }
+  }
+
+  protected void checkIfMediaComplies(DigitalMedia dm)
+      throws DiSSCoDataException {
+    for (var check : mediaComplianceChecks) {
+      if (!check.test(dm)) {
+        throw new DiSSCoDataException("Media with id " + dm.getAcAccessURI()
+            + " does not comply with the requirements, ignoring record");
+      }
+    }
+  }
+
+  private boolean isAccessURIPresent(DigitalMedia dm) {
+    if (dm.getAcAccessURI() != null) {
+      return true;
+    } else {
+      report.addMediaIssues("Missing Access URI");
+      return false;
+    }
+  }
+
+  private boolean digitalMediaLicenseComplies(DigitalMedia dm) {
+    var license = dm.getDctermsRights();
+    if (!licenseComplies(license)) {
+      report.addMediaIssues("License '" + license + NOT_ACCEPTED);
+      return false;
+    } else {
+      return true;
     }
   }
 }

--- a/src/main/java/eu/dissco/core/translator/service/BioCaseService.java
+++ b/src/main/java/eu/dissco/core/translator/service/BioCaseService.java
@@ -95,7 +95,6 @@ public class BioCaseService extends AbstractDataRetrievalService {
         this.masProperties = masProperties;
         this.digitalSpecimenDirector = digitalSpecimenDirector;
         this.fdoProperties = fdoProperties;
-
     }
 
     @Override

--- a/src/main/java/eu/dissco/core/translator/service/BioCaseService.java
+++ b/src/main/java/eu/dissco/core/translator/service/BioCaseService.java
@@ -1,13 +1,23 @@
 package eu.dissco.core.translator.service;
 
 
-import efg.*;
+import efg.DataSets;
 import efg.DataSets.DataSet;
+import efg.EarthScienceSpecimenType;
+import efg.MineralRockIdentifiedType;
+import efg.MultiMediaObject;
+import efg.Unit;
 import eu.dissco.core.translator.Profiles;
 import eu.dissco.core.translator.component.EmlComponent;
 import eu.dissco.core.translator.component.SourceSystemComponent;
 import eu.dissco.core.translator.database.jooq.enums.JobState;
-import eu.dissco.core.translator.domain.*;
+import eu.dissco.core.translator.domain.BioCasePartResult;
+import eu.dissco.core.translator.domain.DigitalMediaEvent;
+import eu.dissco.core.translator.domain.DigitalMediaWrapper;
+import eu.dissco.core.translator.domain.DigitalSpecimenEvent;
+import eu.dissco.core.translator.domain.DigitalSpecimenWrapper;
+import eu.dissco.core.translator.domain.TranslatorJobReport;
+import eu.dissco.core.translator.domain.TranslatorJobResult;
 import eu.dissco.core.translator.exception.DiSSCoDataException;
 import eu.dissco.core.translator.exception.DisscoEfgParsingException;
 import eu.dissco.core.translator.exception.ReachedMaximumLimitException;
@@ -19,7 +29,24 @@ import freemarker.template.Configuration;
 import freemarker.template.TemplateException;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
-import lombok.RequiredArgsConstructor;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.transform.Source;
+import javax.xml.transform.dom.DOMSource;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -31,26 +58,9 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ObjectNode;
 
-import javax.xml.namespace.QName;
-import javax.xml.stream.XMLEventReader;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.transform.Source;
-import javax.xml.transform.dom.DOMSource;
-import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.time.Duration;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-
 @Slf4j
 @Service
 @Profile(Profiles.BIOCASE)
-@RequiredArgsConstructor
 public class BioCaseService extends AbstractDataRetrievalService {
 
     private static final String START_AT = "startAt";
@@ -70,13 +80,30 @@ public class BioCaseService extends AbstractDataRetrievalService {
     private final BaseDigitalObjectDirector digitalSpecimenDirector;
     private final FdoProperties fdoProperties;
 
+    public BioCaseService(JsonMapper mapper, ApplicationProperties applicationProperties, WebClient webClient,
+                          SourceSystemComponent sourceSystemComponent, Configuration configuration,
+                          XMLInputFactory xmlFactory, RabbitMqService rabbitMqService, MasProperties masProperties,
+                          BaseDigitalObjectDirector digitalSpecimenDirector, FdoProperties fdoProperties) {
+        super(new TranslatorJobReport());
+        this.mapper = mapper;
+        this.applicationProperties = applicationProperties;
+        this.webClient = webClient;
+        this.sourceSystemComponent = sourceSystemComponent;
+        this.configuration = configuration;
+        this.xmlFactory = xmlFactory;
+        this.rabbitMqService = rabbitMqService;
+        this.masProperties = masProperties;
+        this.digitalSpecimenDirector = digitalSpecimenDirector;
+        this.fdoProperties = fdoProperties;
+
+    }
+
     @Override
     public TranslatorJobResult retrieveData() {
         var uri = sourceSystemComponent.getSourceSystemEndpoint();
         var templateProperties = getTemplateProperties();
         configuration.setNumberFormat("computer");
         var finished = false;
-        var processedRecords = new AtomicInteger(0);
         while (!finished) {
             log.info("Currently at: {} still collecting...", templateProperties.get(START_AT));
             StringWriter writer = fillTemplate(templateProperties);
@@ -84,11 +111,11 @@ public class BioCaseService extends AbstractDataRetrievalService {
                 var partResult = webClient.get().uri(uri + writer)
                         .retrieve()
                         .bodyToMono(String.class).publishOn(Schedulers.boundedElastic()).map(
-                                (String xml) -> handleBioCaseResponse(xml, processedRecords))
+                        this::handleBioCaseResponse)
                         .retryWhen(Retry.backoff(3, Duration.ofSeconds(2)))
                         .toFuture().get();
                 if (partResult.exception()) {
-                    return new TranslatorJobResult(JobState.FAILED, processedRecords.get());
+                    return new TranslatorJobResult(JobState.FAILED, report);
                 }
                 finished = partResult.finished();
                 if (finished) {
@@ -97,24 +124,20 @@ public class BioCaseService extends AbstractDataRetrievalService {
             } catch (InterruptedException e) {
                 log.error("Failed to get response from uri", e);
                 Thread.currentThread().interrupt();
-                return new TranslatorJobResult(JobState.FAILED, processedRecords.get());
+                return new TranslatorJobResult(JobState.FAILED, report);
             } catch (ExecutionException e) {
                 log.error("Failed to get response from uri", e);
-                return new TranslatorJobResult(JobState.FAILED, processedRecords.get());
+                return new TranslatorJobResult(JobState.FAILED, report);
             }
             updateStartAtParameter(templateProperties);
         }
-        if (processedRecords.get() == 0) {
-            log.info("No records were successfully processed");
-            return new TranslatorJobResult(JobState.FAILED, processedRecords.get());
-        }
-        return new TranslatorJobResult(JobState.COMPLETED, processedRecords.get());
+        return new TranslatorJobResult(JobState.COMPLETED, report);
     }
 
-    private BioCasePartResult handleBioCaseResponse(String xml, AtomicInteger processedRecords) {
+    private BioCasePartResult handleBioCaseResponse(String xml) {
         try {
             var xmlEventReader = xmlFactory.createXMLEventReader(new StringReader(xml));
-            return handleBioCasePage(processedRecords, xmlEventReader);
+            return handleBioCasePage(xmlEventReader);
         } catch (XMLStreamException | JAXBException | IOException e) {
             log.error("Error converting response to XML", e);
             return new BioCasePartResult(true, true);
@@ -125,7 +148,7 @@ public class BioCaseService extends AbstractDataRetrievalService {
         }
     }
 
-    private BioCasePartResult handleBioCasePage(AtomicInteger processedRecords, XMLEventReader xmlEventReader) throws XMLStreamException, JAXBException, ReachedMaximumLimitException, IOException {
+    private BioCasePartResult handleBioCasePage(XMLEventReader xmlEventReader) throws XMLStreamException, JAXBException, ReachedMaximumLimitException, IOException {
         var recordCount = 0;
         var recordDropped = 0;
         while (xmlEventReader.hasNext()) {
@@ -138,7 +161,7 @@ public class BioCaseService extends AbstractDataRetrievalService {
                 log.info("Received {} records in BioCase request, {} records dropped", recordCount,
                         recordDropped);
             }
-            retrieveUnitData(xmlEventReader, processedRecords);
+            retrieveUnitData(xmlEventReader);
         }
         if ((recordCount + recordDropped) % applicationProperties.getItemsPerRequest() != 0) {
             log.info("Received records {} does not match requested records {}. "
@@ -150,14 +173,14 @@ public class BioCaseService extends AbstractDataRetrievalService {
         }
     }
 
-    private void retrieveUnitData(XMLEventReader xmlEventReader, AtomicInteger processedRecords)
+    private void retrieveUnitData(XMLEventReader xmlEventReader)
             throws XMLStreamException, JAXBException, ReachedMaximumLimitException, IOException {
         if (isStartElement(xmlEventReader.peek(), "DataSets")) {
-            mapABCD206(xmlEventReader, processedRecords);
+            mapABCD206(xmlEventReader);
         }
     }
 
-    private void mapABCD206(XMLEventReader xmlEventReader, AtomicInteger processedRecords)
+    private void mapABCD206(XMLEventReader xmlEventReader)
             throws JAXBException, ReachedMaximumLimitException, IOException {
         var context = JAXBContext.newInstance(DataSets.class);
         var datasetsMarshaller = context.createUnmarshaller().unmarshal(xmlEventReader, DataSets.class);
@@ -166,17 +189,17 @@ public class BioCaseService extends AbstractDataRetrievalService {
         for (var unit : datasets.getUnits().getUnit()) {
             try {
                 if (applicationProperties.getMaxItems() != null
-                        && processedRecords.get() >= applicationProperties.getMaxItems()) {
+                        && report.getSuccessfulSpecimen() >= applicationProperties.getMaxItems()) {
                     throw new ReachedMaximumLimitException();
                 }
-                processUnit(datasets, unit, processedRecords);
+                processUnit(datasets, unit);
             } catch (DisscoEfgParsingException e) {
                 log.error("Unit could not be processed due to error", e);
             }
         }
     }
 
-    private void processUnit(DataSet dataset, Unit unit, AtomicInteger processedRecords)
+    private void processUnit(DataSet dataset, Unit unit)
             throws DisscoEfgParsingException {
         var unitAttributes = parseToJson(unit);
         var datasetAttribute = getData(mapper.valueToTree(dataset.getMetadata()));
@@ -202,9 +225,9 @@ public class BioCaseService extends AbstractDataRetrievalService {
                             digitalSpecimenWrapper,
                             digitalMedia,
                             masProperties.getForceMasSchedule()));
-            processedRecords.incrementAndGet();
-        } catch (DiSSCoDataException e) {
-            log.error("Encountered data issue with record: {}", unitAttributes, e);
+            report.incrementSuccessfulRecords(digitalMedia.size());
+        } catch (DiSSCoDataException _) {
+            log.warn("Encountered data issue with record: {}", unitAttributes);
         }
     }
 

--- a/src/main/java/eu/dissco/core/translator/service/DwcaService.java
+++ b/src/main/java/eu/dissco/core/translator/service/DwcaService.java
@@ -7,6 +7,7 @@ import eu.dissco.core.translator.domain.DigitalMediaEvent;
 import eu.dissco.core.translator.domain.DigitalMediaWrapper;
 import eu.dissco.core.translator.domain.DigitalSpecimenEvent;
 import eu.dissco.core.translator.domain.DigitalSpecimenWrapper;
+import eu.dissco.core.translator.domain.TranslatorJobReport;
 import eu.dissco.core.translator.domain.TranslatorJobResult;
 import eu.dissco.core.translator.exception.DiSSCoDataException;
 import eu.dissco.core.translator.exception.DisscoRepositoryException;
@@ -42,7 +43,6 @@ import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.gbif.dwc.Archive;
@@ -63,7 +63,6 @@ import tools.jackson.databind.node.ObjectNode;
 @Service
 @Slf4j
 @Profile(Profiles.DWCA)
-@RequiredArgsConstructor
 public class DwcaService extends AbstractDataRetrievalService {
 
   public static final String GBIF_MULTIMEDIA = "gbif:Multimedia";
@@ -84,11 +83,29 @@ public class DwcaService extends AbstractDataRetrievalService {
   private final ApplicationProperties applicationProperties;
   private final XMLInputFactory xmlFactory;
 
+  public DwcaService(JsonMapper mapper, WebClient webClient,
+      DwcaProperties dwcaProperties, RabbitMqService rabbitMqService, MasProperties masProperties,
+      SourceSystemComponent sourceSystemComponent, DwcaRepository dwcaRepository,
+      BaseDigitalObjectDirector digitalSpecimenDirector, FdoProperties fdoProperties,
+      ApplicationProperties applicationProperties, XMLInputFactory xmlFactory) {
+    super(new TranslatorJobReport());
+    this.mapper = mapper;
+    this.webClient = webClient;
+    this.dwcaProperties = dwcaProperties;
+    this.rabbitMqService = rabbitMqService;
+    this.masProperties = masProperties;
+    this.sourceSystemComponent = sourceSystemComponent;
+    this.dwcaRepository = dwcaRepository;
+    this.digitalSpecimenDirector = digitalSpecimenDirector;
+    this.fdoProperties = fdoProperties;
+    this.applicationProperties = applicationProperties;
+    this.xmlFactory = xmlFactory;
+  }
+
   @Override
   public TranslatorJobResult retrieveData() {
     var endpoint = sourceSystemComponent.getSourceSystemEndpoint();
     Archive archive = null;
-    var processedRecords = new AtomicInteger(0);
     try {
       var file = Path.of(dwcaProperties.getDownloadFile());
       var buffer = webClient.get().uri(URI.create(endpoint)).retrieve()
@@ -97,34 +114,30 @@ public class DwcaService extends AbstractDataRetrievalService {
           .then().toFuture().get();
       archive = DwcFiles.fromCompressed(file, Path.of(dwcaProperties.getTempFolder()));
       var ids = postArchiveToDatabase(archive);
-      getSpecimenData(ids, archive, processedRecords);
+      getSpecimenData(ids, archive);
     } catch (IOException e) {
       log.error("Failed to open output stream for download file", e);
-      return new TranslatorJobResult(JobState.FAILED, processedRecords.get());
+      return new TranslatorJobResult(JobState.FAILED, report);
     } catch (ExecutionException e) {
       log.error("Failed during downloading file with exception", e.getCause());
-      return new TranslatorJobResult(JobState.FAILED, processedRecords.get());
+      return new TranslatorJobResult(JobState.FAILED, report);
     } catch (InterruptedException e) {
       log.error("Failed during downloading file due to interruption", e);
       Thread.currentThread().interrupt();
-      return new TranslatorJobResult(JobState.FAILED, processedRecords.get());
+      return new TranslatorJobResult(JobState.FAILED, report);
     } catch (DisscoRepositoryException e) {
       log.error("Failed during batch copy into temp tables with exception", e);
-      return new TranslatorJobResult(JobState.FAILED, processedRecords.get());
+      return new TranslatorJobResult(JobState.FAILED, report);
     } finally {
       if (archive != null) {
         log.info("Cleaning up database tables");
         removeTempTables(archive);
       }
     }
-    if (processedRecords.get() == 0) {
-      log.info("No records were successfully processed");
-      return new TranslatorJobResult(JobState.FAILED, processedRecords.get());
-    }
-    return new TranslatorJobResult(JobState.COMPLETED, processedRecords.get());
+    return new TranslatorJobResult(JobState.COMPLETED, report);
   }
 
-  public void getSpecimenData(Set<String> ids, Archive archive, AtomicInteger processedRecords)
+  public void getSpecimenData(Set<String> ids, Archive archive)
       throws IOException {
     var batches = prepareChunks(ids, 10000);
     sourceSystemComponent.storeEmlRecord(archive.getMetadataLocationFile());
@@ -137,7 +150,7 @@ public class DwcaService extends AbstractDataRetrievalService {
         log.info("Got specimen batch: {}", batch.size());
         addExtensionsToSpecimen(archive, batch, specimenData);
         log.info("Start translation and publishing of batch: {}", specimenData.size());
-        processDigitalSpecimen(specimenData.values(), optionalEmlData, processedRecords);
+        processDigitalSpecimen(specimenData.values(), optionalEmlData);
       }
     } catch (ReachedMaximumLimitException _) {
       log.warn("Reached maximum limit of {} processed specimens out of {} specimens available",
@@ -168,12 +181,12 @@ public class DwcaService extends AbstractDataRetrievalService {
   }
 
   private void processDigitalSpecimen(Collection<ObjectNode> fullRecords,
-      Optional<Map<String, String>> optionalEmlData, AtomicInteger processedRecords)
+      Optional<Map<String, String>> optionalEmlData)
       throws ReachedMaximumLimitException {
     for (var fullRecord : fullRecords) {
       if (fullRecord != null) {
         if (applicationProperties.getMaxItems() != null
-            && processedRecords.get() >= applicationProperties.getMaxItems()) {
+            && report.getSuccessfulSpecimen() >= applicationProperties.getMaxItems()) {
           throw new ReachedMaximumLimitException();
         }
         try {
@@ -182,12 +195,13 @@ public class DwcaService extends AbstractDataRetrievalService {
           log.debug("Digital Specimen: {}", digitalObjects);
           var translatorEvent = new DigitalSpecimenEvent(
               masProperties.getSpecimenMass(),
-              digitalObjects.getLeft(), digitalObjects.getRight(),
+              digitalObjects.getLeft(),
+              digitalObjects.getRight(),
               masProperties.getForceMasSchedule());
           rabbitMqService.sendMessage(translatorEvent);
-          processedRecords.incrementAndGet();
-        } catch (DiSSCoDataException e) {
-          log.error("Encountered data issue with record: {}", fullRecord, e);
+          report.incrementSuccessfulRecords(digitalObjects.getRight().size());
+        } catch (DiSSCoDataException _) {
+          log.warn("Encountered data issue with record: {}", fullRecord);
         }
       }
     }
@@ -373,7 +387,7 @@ public class DwcaService extends AbstractDataRetrievalService {
   private Collection<List<String>> prepareChunks(Set<String> inputList, int chunkSize) {
     AtomicInteger counter = new AtomicInteger();
     return inputList.stream()
-        .collect(Collectors.groupingBy(it -> counter.getAndIncrement() / chunkSize)).values();
+        .collect(Collectors.groupingBy(_ -> counter.getAndIncrement() / chunkSize)).values();
   }
 
   private Set<String> postArchiveToDatabase(Archive archive) throws DisscoRepositoryException {

--- a/src/main/java/eu/dissco/core/translator/service/TranslatorJobRecordService.java
+++ b/src/main/java/eu/dissco/core/translator/service/TranslatorJobRecordService.java
@@ -28,12 +28,10 @@ public class TranslatorJobRecordService {
   public void updateJobState(UUID jobId, TranslatorJobResult processingResult) {
     var jobState = processingResult.jobState();
     if (jobState == JobState.COMPLETED) {
-      log.info("Job with id {} finished successfully. Processed {} records", jobId,
-          processingResult.processedRecords());
+      log.info("Job with id {} finished successfully. Job report: {}", jobId, processingResult);
       repository.updateJobState(jobId, processingResult, null);
     } else {
-      log.info("Job with id {} failed. Processed {} records", jobId,
-          processingResult.processedRecords());
+      log.info("Job with id {} failed. Job report: {}", jobId, processingResult);
       repository.updateJobState(jobId, processingResult, ErrorCode.DISSCO_EXCEPTION);
     }
   }

--- a/src/test/java/eu/dissco/core/translator/TestUtils.java
+++ b/src/test/java/eu/dissco/core/translator/TestUtils.java
@@ -107,12 +107,12 @@ public class TestUtils {
   }
 
   public static TranslatorJobReport givenReport(int successfulSpecimen) {
-    return new TranslatorJobReport(emptyMap(), emptyMap(), successfulSpecimen, 0);
+    return new TranslatorJobReport(emptyMap(), emptyMap(), successfulSpecimen, 0, 0, 0);
   }
 
   public static TranslatorJobReport givenReport(int successfulSpecimen, int successfulMedia) {
     return new TranslatorJobReport(emptyMap(), emptyMap(), successfulSpecimen,
-        successfulMedia);
+        successfulMedia, 0, 0);
   }
 
   public static DigitalSpecimen givenDigitalSpecimen() {

--- a/src/test/java/eu/dissco/core/translator/TestUtils.java
+++ b/src/test/java/eu/dissco/core/translator/TestUtils.java
@@ -1,10 +1,12 @@
 package eu.dissco.core.translator;
 
 import static eu.dissco.core.translator.configuration.ApplicationConfiguration.DATE_STRING;
+import static java.util.Collections.emptyMap;
 
 import com.fasterxml.jackson.annotation.JsonSetter.Value;
 import com.fasterxml.jackson.annotation.Nulls;
 import eu.dissco.core.translator.domain.SourceSystemInformation;
+import eu.dissco.core.translator.domain.TranslatorJobReport;
 import eu.dissco.core.translator.schema.DigitalMedia;
 import eu.dissco.core.translator.schema.DigitalSpecimen;
 import java.io.IOException;
@@ -16,8 +18,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.provider.Arguments;
 import org.springframework.core.io.ClassPathResource;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -106,6 +106,15 @@ public class TestUtils {
         .readAllBytes(), StandardCharsets.UTF_8);
   }
 
+  public static TranslatorJobReport givenReport(int successfulSpecimen) {
+    return new TranslatorJobReport(emptyMap(), emptyMap(), successfulSpecimen, 0);
+  }
+
+  public static TranslatorJobReport givenReport(int successfulSpecimen, int successfulMedia) {
+    return new TranslatorJobReport(emptyMap(), emptyMap(), successfulSpecimen,
+        successfulMedia);
+  }
+
   public static DigitalSpecimen givenDigitalSpecimen() {
     return new DigitalSpecimen()
         .withDwcBasisOfRecord("PreservedSpecimen")
@@ -118,14 +127,6 @@ public class TestUtils {
     return new DigitalMedia()
         .withDctermsRights("https://creativecommons.org/publicdomain/zero/1.0/legalcode")
         .withAcAccessURI("https://accessuri.eu/image_1");
-  }
-
-  public static Stream<Arguments> provideInvalidDigitalSpecimen() {
-    return Stream.of(
-        Arguments.of(new DigitalSpecimen().withOdsNormalisedPhysicalSpecimenID(
-            NORMALISED_PHYSICAL_SPECIMEN_ID)),
-        Arguments.of(new DigitalSpecimen().withOdsOrganisationID(ORGANISATION_ID))
-    );
   }
 
   public static SourceSystemInformation givenSourceSystemInformation() {

--- a/src/test/java/eu/dissco/core/translator/repository/BaseRepositoryIT.java
+++ b/src/test/java/eu/dissco/core/translator/repository/BaseRepositoryIT.java
@@ -9,19 +9,19 @@ import org.jooq.SQLDialect;
 import org.jooq.impl.DefaultDSLContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 class BaseRepositoryIT {
 
   private static final DockerImageName POSTGIS =
-      DockerImageName.parse("postgres:15.2").asCompatibleSubstituteFor(IMAGE);
+      DockerImageName.parse("postgres:18.3").asCompatibleSubstituteFor(IMAGE);
 
   @Container
-  private static final PostgreSQLContainer<?> CONTAINER = new PostgreSQLContainer<>(POSTGIS);
+  private static final PostgreSQLContainer CONTAINER = new PostgreSQLContainer(POSTGIS);
   protected DSLContext context;
   protected HikariDataSource dataSource;
 

--- a/src/test/java/eu/dissco/core/translator/repository/DwcaRepositoryTest.java
+++ b/src/test/java/eu/dissco/core/translator/repository/DwcaRepositoryTest.java
@@ -5,7 +5,8 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 
 import eu.dissco.core.translator.component.DataMappingComponent;
 import eu.dissco.core.translator.exception.IllegalDataException;

--- a/src/test/java/eu/dissco/core/translator/repository/TranslatorJobRecordRepositoryIT.java
+++ b/src/test/java/eu/dissco/core/translator/repository/TranslatorJobRecordRepositoryIT.java
@@ -1,7 +1,9 @@
 package eu.dissco.core.translator.repository;
 
 import static eu.dissco.core.translator.TestUtils.ENDPOINT;
+import static eu.dissco.core.translator.TestUtils.MAPPER;
 import static eu.dissco.core.translator.TestUtils.SOURCE_SYSTEM_ID;
+import static eu.dissco.core.translator.TestUtils.givenReport;
 import static eu.dissco.core.translator.database.jooq.Tables.SOURCE_SYSTEM;
 import static eu.dissco.core.translator.database.jooq.Tables.TRANSLATOR_JOB_RECORD;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,7 +25,7 @@ class TranslatorJobRecordRepositoryIT extends BaseRepositoryIT {
 
   @BeforeEach
   void setup() {
-    repository = new TranslatorJobRecordRepository(context);
+    repository = new TranslatorJobRecordRepository(context, MAPPER);
   }
 
   @AfterEach
@@ -58,7 +60,8 @@ class TranslatorJobRecordRepositoryIT extends BaseRepositoryIT {
     repository.createNewJobRecord(jobId, SOURCE_SYSTEM_ID);
 
     // When
-    repository.updateJobState(jobId, new TranslatorJobResult(JobState.COMPLETED, 50000), null);
+    repository.updateJobState(jobId,
+        new TranslatorJobResult(JobState.COMPLETED, givenReport(50000)), null);
 
     // Then
     var result = context.fetchOne(TRANSLATOR_JOB_RECORD, TRANSLATOR_JOB_RECORD.JOB_ID.eq(jobId));
@@ -80,7 +83,7 @@ class TranslatorJobRecordRepositoryIT extends BaseRepositoryIT {
     repository.createNewJobRecord(jobId, SOURCE_SYSTEM_ID);
 
     // When
-    repository.updateJobState(jobId, new TranslatorJobResult(JobState.FAILED, 421312),
+    repository.updateJobState(jobId, new TranslatorJobResult(JobState.FAILED, givenReport(421312)),
         ErrorCode.DISSCO_EXCEPTION);
 
     // Then

--- a/src/test/java/eu/dissco/core/translator/service/BioCaseServiceTest.java
+++ b/src/test/java/eu/dissco/core/translator/service/BioCaseServiceTest.java
@@ -1,9 +1,13 @@
 package eu.dissco.core.translator.service;
 
 import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static eu.dissco.core.translator.TestUtils.NORMALISED_PHYSICAL_SPECIMEN_ID;
+import static eu.dissco.core.translator.TestUtils.ORGANISATION_ID;
 import static eu.dissco.core.translator.TestUtils.givenDigitalMedia;
 import static eu.dissco.core.translator.TestUtils.givenDigitalSpecimen;
+import static eu.dissco.core.translator.TestUtils.givenReport;
 import static eu.dissco.core.translator.TestUtils.loadResourceFile;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -15,6 +19,7 @@ import static org.mockito.Mockito.times;
 import eu.dissco.core.translator.component.SourceSystemComponent;
 import eu.dissco.core.translator.database.jooq.enums.JobState;
 import eu.dissco.core.translator.domain.DigitalSpecimenEvent;
+import eu.dissco.core.translator.domain.TranslatorJobReport;
 import eu.dissco.core.translator.domain.TranslatorJobResult;
 import eu.dissco.core.translator.properties.ApplicationProperties;
 import eu.dissco.core.translator.properties.FdoProperties;
@@ -25,11 +30,15 @@ import eu.dissco.core.translator.terms.BaseDigitalObjectDirector;
 import freemarker.cache.FileTemplateLoader;
 import freemarker.template.Configuration;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
 import javax.xml.stream.XMLInputFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -91,7 +100,7 @@ class BioCaseServiceTest {
     if (processedRecords == null) {
       processedRecords = 100;
     }
-    var expectedResult = new TranslatorJobResult(JobState.COMPLETED, processedRecords);
+    var expectedResult = new TranslatorJobResult(JobState.COMPLETED, givenReport(processedRecords));
     given(sourceSystemComponent.getSourceSystemEndpoint()).willReturn("https://endpoint.com");
     given(responseSpec.bodyToMono(any(Class.class))).willReturn(
             Mono.just(loadResourceFile("biocase/geocase-record-dropped.xml")))
@@ -117,7 +126,7 @@ class BioCaseServiceTest {
   @Test
   void testRetrieveDataWithMedia206() throws Exception {
     // Given
-    var expectedResult = new TranslatorJobResult(JobState.COMPLETED, 100);
+    var expectedResult = new TranslatorJobResult(JobState.COMPLETED, givenReport(100, 100));
     given(sourceSystemComponent.getSourceSystemEndpoint()).willReturn("https://endpoint.com");
     given(responseSpec.bodyToMono(any(Class.class))).willReturn(
         Mono.just(loadResourceFile("biocase/biocase-206-with-media.xml")));
@@ -143,7 +152,8 @@ class BioCaseServiceTest {
   @Test
   void testRetrieveDataInvalidMedia() throws Exception {
     // Given
-    var expectedResult = new TranslatorJobResult(JobState.COMPLETED, 1);
+    var expectedResult = new TranslatorJobResult(JobState.COMPLETED,
+        new TranslatorJobReport(new HashMap<>(), Map.of("License 'null' is not accepted", 2), 1, 0));
     given(sourceSystemComponent.getSourceSystemEndpoint()).willReturn("https://endpoint.com");
     given(responseSpec.bodyToMono(any(Class.class))).willReturn(
         Mono.just(loadResourceFile("biocase/biocase-206-with-invalid-media.xml")));
@@ -166,10 +176,10 @@ class BioCaseServiceTest {
   }
 
   @ParameterizedTest
-  @MethodSource("eu.dissco.core.translator.TestUtils#provideInvalidDigitalSpecimen")
-  void testRetrieveDataInvalidSpecimen(DigitalSpecimen digitalSpecimen) throws Exception {
+  @MethodSource("provideInvalidDigitalSpecimen")
+  void testRetrieveDataInvalidSpecimen(DigitalSpecimen digitalSpecimen, TranslatorJobReport report) throws Exception {
     // Given
-    var expectedResult = new TranslatorJobResult(JobState.FAILED, 0);
+    var expectedResult = new TranslatorJobResult(JobState.COMPLETED, report);
     given(sourceSystemComponent.getSourceSystemEndpoint()).willReturn("https://endpoint.com");
     given(responseSpec.bodyToMono(any(Class.class))).willReturn(
         Mono.just(loadResourceFile("biocase/biocase-206-with-media.xml")));
@@ -184,6 +194,17 @@ class BioCaseServiceTest {
     assertThat(result).isEqualTo(expectedResult);
     then(webClient).should(times(1)).get();
     then(rabbitMqService).shouldHaveNoInteractions();
+  }
+
+  private static Stream<Arguments> provideInvalidDigitalSpecimen() {
+    return Stream.of(
+        Arguments.of(new DigitalSpecimen().withOdsNormalisedPhysicalSpecimenID(
+                NORMALISED_PHYSICAL_SPECIMEN_ID),
+            new TranslatorJobReport(Map.of("Missing Organisation ID", 100), emptyMap(), 0, 0)),
+        Arguments.of(new DigitalSpecimen().withOdsOrganisationID(ORGANISATION_ID),
+            new TranslatorJobReport(Map.of("Missing Normalised Physical Specimen Identifier", 100),
+                emptyMap(), 0, 0))
+    );
   }
 
   private void givenJsonWebclient() {

--- a/src/test/java/eu/dissco/core/translator/service/BioCaseServiceTest.java
+++ b/src/test/java/eu/dissco/core/translator/service/BioCaseServiceTest.java
@@ -153,7 +153,7 @@ class BioCaseServiceTest {
   void testRetrieveDataInvalidMedia() throws Exception {
     // Given
     var expectedResult = new TranslatorJobResult(JobState.COMPLETED,
-        new TranslatorJobReport(new HashMap<>(), Map.of("License 'null' is not accepted", 2), 1, 0));
+        new TranslatorJobReport(new HashMap<>(), Map.of("License 'null' is not accepted", 2), 1, 0,0, 2));
     given(sourceSystemComponent.getSourceSystemEndpoint()).willReturn("https://endpoint.com");
     given(responseSpec.bodyToMono(any(Class.class))).willReturn(
         Mono.just(loadResourceFile("biocase/biocase-206-with-invalid-media.xml")));
@@ -200,10 +200,10 @@ class BioCaseServiceTest {
     return Stream.of(
         Arguments.of(new DigitalSpecimen().withOdsNormalisedPhysicalSpecimenID(
                 NORMALISED_PHYSICAL_SPECIMEN_ID),
-            new TranslatorJobReport(Map.of("Missing Organisation ID", 100), emptyMap(), 0, 0)),
+            new TranslatorJobReport(Map.of("Missing Organisation ID", 100), emptyMap(), 0, 0, 100, 0)),
         Arguments.of(new DigitalSpecimen().withOdsOrganisationID(ORGANISATION_ID),
             new TranslatorJobReport(Map.of("Missing Normalised Physical Specimen Identifier", 100),
-                emptyMap(), 0, 0))
+                emptyMap(), 0, 0, 100, 0))
     );
   }
 

--- a/src/test/java/eu/dissco/core/translator/service/DwcaServiceTest.java
+++ b/src/test/java/eu/dissco/core/translator/service/DwcaServiceTest.java
@@ -1,6 +1,13 @@
 package eu.dissco.core.translator.service;
 
-import static eu.dissco.core.translator.TestUtils.*;
+import static eu.dissco.core.translator.TestUtils.MAPPER;
+import static eu.dissco.core.translator.TestUtils.NORMALISED_PHYSICAL_SPECIMEN_ID;
+import static eu.dissco.core.translator.TestUtils.ORGANISATION_ID;
+import static eu.dissco.core.translator.TestUtils.SOURCE_SYSTEM_ID;
+import static eu.dissco.core.translator.TestUtils.givenDigitalMedia;
+import static eu.dissco.core.translator.TestUtils.givenDigitalSpecimen;
+import static eu.dissco.core.translator.TestUtils.givenReport;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -15,6 +22,7 @@ import eu.dissco.core.translator.TestUtils;
 import eu.dissco.core.translator.component.SourceSystemComponent;
 import eu.dissco.core.translator.database.jooq.enums.JobState;
 import eu.dissco.core.translator.domain.DigitalSpecimenEvent;
+import eu.dissco.core.translator.domain.TranslatorJobReport;
 import eu.dissco.core.translator.domain.TranslatorJobResult;
 import eu.dissco.core.translator.properties.ApplicationProperties;
 import eu.dissco.core.translator.properties.DwcaProperties;
@@ -32,12 +40,14 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import javax.xml.stream.XMLInputFactory;
 import org.gbif.dwc.terms.Term;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -109,7 +119,7 @@ class DwcaServiceTest {
     if (processedRecords == null) {
       processedRecords = 9;
     }
-    var expected = new TranslatorJobResult(JobState.COMPLETED, processedRecords);
+    var expected = new TranslatorJobResult(JobState.COMPLETED, givenReport(processedRecords));
     var captor = ArgumentCaptor.forClass(JsonNode.class);
     givenDWCA("/dwca-rbins.zip");
     given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(9));
@@ -137,7 +147,7 @@ class DwcaServiceTest {
   @Test
   void testRetrieveDataEmlException() throws Exception {
     // Given
-    var expected = new TranslatorJobResult(JobState.COMPLETED, 9);
+    var expected = new TranslatorJobResult(JobState.COMPLETED, givenReport(9));
     var captor = ArgumentCaptor.forClass(JsonNode.class);
     givenDWCA("/dwca-rbins-invalid-eml.zip");
     given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(9));
@@ -162,7 +172,7 @@ class DwcaServiceTest {
   @Test
   void testRetrieveDataWithLicenseText() throws Exception {
     // Given
-    var expected = new TranslatorJobResult(JobState.COMPLETED, 9);
+    var expected = new TranslatorJobResult(JobState.COMPLETED, givenReport(9));
     var captor = ArgumentCaptor.forClass(JsonNode.class);
     givenDWCA("/dwca-rbins-license-text.zip");
     given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(9));
@@ -188,10 +198,11 @@ class DwcaServiceTest {
   }
 
   @ParameterizedTest
-  @MethodSource("eu.dissco.core.translator.TestUtils#provideInvalidDigitalSpecimen")
-  void testRetrieveDataInvalidSpecimen(DigitalSpecimen digitalSpecimen) throws Exception {
+  @MethodSource("provideInvalidDigitalSpecimen")
+  void testRetrieveDataInvalidSpecimen(DigitalSpecimen digitalSpecimen, TranslatorJobReport report)
+      throws Exception {
     // Given
-    var expected = new TranslatorJobResult(JobState.FAILED, 0);
+    var expected = new TranslatorJobResult(JobState.COMPLETED, report);
     givenDWCA("/dwca-rbins.zip");
     given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(9));
     given(digitalSpecimenDirector.assembleDigitalSpecimenTerm(any(JsonNode.class), anyBoolean()))
@@ -207,6 +218,17 @@ class DwcaServiceTest {
     then(sourceSystemComponent).should().storeEmlRecord(any(File.class));
     then(rabbitMqService).shouldHaveNoInteractions();
     cleanup("src/test/resources/dwca/test/dwca-rbins.zip");
+  }
+
+  private static Stream<Arguments> provideInvalidDigitalSpecimen() {
+    return Stream.of(
+        Arguments.of(new DigitalSpecimen().withOdsNormalisedPhysicalSpecimenID(
+                NORMALISED_PHYSICAL_SPECIMEN_ID),
+            new TranslatorJobReport(Map.of("Missing Organisation ID", 9), emptyMap(), 0, 0)),
+        Arguments.of(new DigitalSpecimen().withOdsOrganisationID(ORGANISATION_ID),
+            new TranslatorJobReport(Map.of("Missing Normalised Physical Specimen Identifier", 9),
+                emptyMap(), 0, 0))
+    );
   }
 
 
@@ -225,7 +247,7 @@ class DwcaServiceTest {
   @Test
   void testRetrieveDataWithGbifMedia() throws Exception {
     // Given
-    var expected = new TranslatorJobResult(JobState.COMPLETED, 19);
+    var expected = new TranslatorJobResult(JobState.COMPLETED, givenReport(19, 19));
     var imageMap = givenImageMap(19);
     imageMap.put("id:1", List.of(MAPPER.createObjectNode()));
     givenDWCA("/dwca-kew-gbif-media.zip");
@@ -269,7 +291,7 @@ class DwcaServiceTest {
   @Test
   void testRetrieveDataWithAcMedia() throws Exception {
     // Given
-    var expected = new TranslatorJobResult(JobState.COMPLETED, 14);
+    var expected = new TranslatorJobResult(JobState.COMPLETED, givenReport(14, 14));
     givenDWCA("/dwca-naturalis-ac-media.zip");
     given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(14));
     given(dwcaRepository.getRecords(anyList(),
@@ -297,7 +319,8 @@ class DwcaServiceTest {
   @Test
   void testRetrieveDataWithInvalidAcMedia() throws Exception {
     // Given
-    var expected = new TranslatorJobResult(JobState.COMPLETED, 1);
+    var expected = new TranslatorJobResult(JobState.COMPLETED,
+        new TranslatorJobReport(emptyMap(), Map.of("License 'null' is not accepted", 1), 1, 0));
     givenDWCA("/dwca-invalid-ac-media.zip");
     given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(1));
     given(dwcaRepository.getRecords(anyList(),
@@ -325,17 +348,18 @@ class DwcaServiceTest {
   @Test
   void testSpecimenRejectedLicense() throws Exception {
     // Given
-    var expected = new TranslatorJobResult(JobState.FAILED, 0);
+    var expected = new TranslatorJobResult(JobState.COMPLETED,
+        new TranslatorJobReport(Map.of("License 'https://creativecommons.org/licenses/by-nc/4.0/legalcode' is not accepted", 14), emptyMap(), 0, 0));
     givenDWCA("/dwca-only-occurrences.zip");
     given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(14));
     given(dwcaRepository.getRecords(anyList(),
-            eq("temp_extension_gw0_tyl_yru_multimedia"))).willReturn(givenImageMap(14));
+        eq("temp_extension_gw0_tyl_yru_multimedia"))).willReturn(givenImageMap(14));
     given(digitalSpecimenDirector.assembleDigitalSpecimenTerm(any(JsonNode.class), anyBoolean()))
-            .willReturn(new DigitalSpecimen()
-                    .withDwcBasisOfRecord("PreservedSpecimen")
-                    .withDctermsLicense("https://creativecommons.org/licenses/by-nc/4.0/legalcode")
-                    .withOdsNormalisedPhysicalSpecimenID(NORMALISED_PHYSICAL_SPECIMEN_ID)
-                    .withOdsOrganisationID(ORGANISATION_ID));
+        .willReturn(new DigitalSpecimen()
+            .withDwcBasisOfRecord("PreservedSpecimen")
+            .withDctermsLicense("https://creativecommons.org/licenses/by-nc/4.0/legalcode")
+            .withOdsNormalisedPhysicalSpecimenID(NORMALISED_PHYSICAL_SPECIMEN_ID)
+            .withOdsOrganisationID(ORGANISATION_ID));
 
     // When
     var result = service.retrieveData();
@@ -353,7 +377,7 @@ class DwcaServiceTest {
   @Test
   void testRetrieveDataWithAssociatedMedia() throws Exception {
     // Given
-    var expected = new TranslatorJobResult(JobState.COMPLETED, 20);
+    var expected = new TranslatorJobResult(JobState.COMPLETED, givenReport(20, 40));
     givenDWCA("/dwca-lux-associated-media.zip");
     given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(
         givenSpecimenMapWithMedia(20));
@@ -411,7 +435,7 @@ class DwcaServiceTest {
   @Test
   void testRetrieveDataNull() throws Exception {
     // Given
-    var expected = new TranslatorJobResult(JobState.FAILED, 0);
+    var expected = new TranslatorJobResult(JobState.COMPLETED, givenReport(0));
     givenDWCA("/dwca-lux-associated-media.zip");
     var nullMap = new HashMap<String, ObjectNode>();
     nullMap.put("id", null);

--- a/src/test/java/eu/dissco/core/translator/service/DwcaServiceTest.java
+++ b/src/test/java/eu/dissco/core/translator/service/DwcaServiceTest.java
@@ -224,10 +224,10 @@ class DwcaServiceTest {
     return Stream.of(
         Arguments.of(new DigitalSpecimen().withOdsNormalisedPhysicalSpecimenID(
                 NORMALISED_PHYSICAL_SPECIMEN_ID),
-            new TranslatorJobReport(Map.of("Missing Organisation ID", 9), emptyMap(), 0, 0)),
+            new TranslatorJobReport(Map.of("Missing Organisation ID", 9), emptyMap(), 0, 0, 9, 0)),
         Arguments.of(new DigitalSpecimen().withOdsOrganisationID(ORGANISATION_ID),
             new TranslatorJobReport(Map.of("Missing Normalised Physical Specimen Identifier", 9),
-                emptyMap(), 0, 0))
+                emptyMap(), 0, 0, 9, 0))
     );
   }
 
@@ -320,7 +320,7 @@ class DwcaServiceTest {
   void testRetrieveDataWithInvalidAcMedia() throws Exception {
     // Given
     var expected = new TranslatorJobResult(JobState.COMPLETED,
-        new TranslatorJobReport(emptyMap(), Map.of("License 'null' is not accepted", 1), 1, 0));
+        new TranslatorJobReport(emptyMap(), Map.of("License 'null' is not accepted", 1), 1, 0, 0, 1));
     givenDWCA("/dwca-invalid-ac-media.zip");
     given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(1));
     given(dwcaRepository.getRecords(anyList(),
@@ -349,7 +349,7 @@ class DwcaServiceTest {
   void testSpecimenRejectedLicense() throws Exception {
     // Given
     var expected = new TranslatorJobResult(JobState.COMPLETED,
-        new TranslatorJobReport(Map.of("License 'https://creativecommons.org/licenses/by-nc/4.0/legalcode' is not accepted", 14), emptyMap(), 0, 0));
+        new TranslatorJobReport(Map.of("License 'https://creativecommons.org/licenses/by-nc/4.0/legalcode' is not accepted", 14), emptyMap(), 0, 0, 14, 0));
     givenDWCA("/dwca-only-occurrences.zip");
     given(dwcaRepository.getCoreRecords(anyList(), anyString())).willReturn(givenSpecimenMap(14));
     given(dwcaRepository.getRecords(anyList(),

--- a/src/test/java/eu/dissco/core/translator/service/RabbitMqServiceTest.java
+++ b/src/test/java/eu/dissco/core/translator/service/RabbitMqServiceTest.java
@@ -19,8 +19,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.rabbitmq.RabbitMQContainer;
 
 @Testcontainers
 class RabbitMqServiceTest {

--- a/src/test/java/eu/dissco/core/translator/service/TranslatorJobRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/translator/service/TranslatorJobRecordServiceTest.java
@@ -1,6 +1,7 @@
 package eu.dissco.core.translator.service;
 
 import static eu.dissco.core.translator.TestUtils.SOURCE_SYSTEM_ID;
+import static eu.dissco.core.translator.TestUtils.givenReport;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -48,7 +49,7 @@ class TranslatorJobRecordServiceTest {
   @Test
   void testUpdateSuccessfulJob() {
     // Given
-    var result = new TranslatorJobResult(JobState.COMPLETED, 50000);
+    var result = new TranslatorJobResult(JobState.COMPLETED, givenReport(50000));
 
     // When
     service.updateJobState(TestUtils.JOB_ID, result);
@@ -60,7 +61,7 @@ class TranslatorJobRecordServiceTest {
   @Test
   void testUpdateFailedJob() {
     // Given
-    var result = new TranslatorJobResult(JobState.FAILED, 50000);
+    var result = new TranslatorJobResult(JobState.FAILED, givenReport(50000));
 
     // When
     service.updateJobState(TestUtils.JOB_ID, result);

--- a/src/test/java/eu/dissco/core/translator/terms/utils/LicenseUtilsTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/utils/LicenseUtilsTest.java
@@ -1,16 +1,22 @@
 package eu.dissco.core.translator.terms.utils;
 
+import static eu.dissco.core.translator.domain.License.CC0;
+import static eu.dissco.core.translator.domain.License.CC_BY;
+import static eu.dissco.core.translator.domain.License.CC_BY_NC;
+import static eu.dissco.core.translator.domain.License.CC_BY_NC_ND;
+import static eu.dissco.core.translator.domain.License.CC_BY_ND;
+import static eu.dissco.core.translator.domain.License.CC_BY_SA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import eu.dissco.core.translator.domain.License;
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import java.util.stream.Stream;
-
-import static eu.dissco.core.translator.domain.License.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 
 class LicenseUtilsTest {

--- a/src/test/resources/db/migration/V1__init_db.sql
+++ b/src/test/resources/db/migration/V1__init_db.sql
@@ -2,34 +2,34 @@ create type translator_type as enum ('biocase', 'dwca');
 
 create table source_system
 (
-    id text not null
+    id              text                     not null
         primary key,
-    version integer default 1 not null,
-    name text not null,
-    endpoint text not null,
-    created timestamp with time zone not null,
-    modified timestamp with time zone not null,
-    tombstoned timestamp with time zone,
-    mapping_id text not null,
-    creator text not null,
-    translator_type translator_type not null,
-    data jsonb not null,
-    dwc_dp_link text,
-    dwca_link text,
-    eml bytea
+    version         integer default 1        not null,
+    name            text                     not null,
+    endpoint        text                     not null,
+    created         timestamp with time zone not null,
+    modified        timestamp with time zone not null,
+    tombstoned      timestamp with time zone,
+    mapping_id      text                     not null,
+    creator         text                     not null,
+    translator_type translator_type          not null,
+    data            jsonb                    not null,
+    dwc_dp_link     text,
+    dwca_link       text,
+    eml             bytea
 );
 
 create table data_mapping
 (
-    id                   text                     not null,
-    version              integer                  not null,
-    name                 text                     not null,
-    created              timestamp with time zone not null,
-    modified             timestamp with time zone not null,
-    date_tombstoned      timestamp with time zone,
-    creator              text                     not null,
+    id                    text                     not null,
+    version               integer                  not null,
+    name                  text                     not null,
+    created               timestamp with time zone not null,
+    modified              timestamp with time zone not null,
+    date_tombstoned       timestamp with time zone,
+    creator               text                     not null,
     mapping_data_standard varchar                  not null,
-    data                 jsonb                    not null,
+    data                  jsonb                    not null,
     constraint data_mapping_pk
         primary key (id, version)
 );
@@ -46,6 +46,7 @@ create table translator_job_record
     time_started      timestamp with time zone not null,
     time_completed    timestamp with time zone,
     processed_records int,
+    report            jsonb,
     error             error_code,
     PRIMARY KEY (job_id, source_system_id),
     FOREIGN KEY (source_system_id) REFERENCES source_system (id)


### PR DESCRIPTION
Generating a report during the run by keeping track of all errors and successfully processed records.
First had this as a component but that didn't work out, got stuck with tests.
This is probably a good middle way so it is a domain object with mutable fields.
An empty report is generated at the start and each record updates the report.
Result looks like this:
```
{
  "successfulMedia": 175241,
  "digitalMediaIssues": {},
  "successfulSpecimen": 291545,
  "digitalSpecimenIssues": {
    "BasisOfRecord \"OtherSpecimen\" is not accepted": 15
  }
}
```

https://naturalis.atlassian.net/browse/DD-3019