### PR TITLE
living or preserved should not rely on basis of record

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -2,23 +2,25 @@
 # Issue with jackson-core, gbif-common would need an update for this
 CVE-2025-52999
 
-# March 2, 2026
-# Issue with alpine image, libpng
-CVE-2026-25646
+# July 23, 2026
+# issue with libexpat, alpine image needs to update
+CVE-2026-56131
+CVE-2026-56407
+CVE-2026-56408
 
-# March 10, 2026
-# Issue with alpine image, zlib: zlib: Arbitrary code execution via buffer overflow
-CVE-2026-22184
+# Issue with p11-kit, alpine image needs to update
+CVE-2026-2100
 
-# March 2, 2026
-# Issue with jackson, spring boot may need to update its jackson 2 version
-# Also could be fixed by upgrading to jackson 3
-GHSA-72hv-8253-57qq
+# July 23, 2026
+# Issue with Jackson core, need to update spring boot
+GHSA-r7wm-3cxj-wff9
+CVE-2026-54512
+CVE-2026-54513
 
-# March 6, 2026
-# jackson-core has Nesting Depth Constraint Bypass, jackson should be fixed to 3.1.X
-CVE-2026-29062
+# July 23, 2026
+# Issue with plexus-utils (jaxb2), need to upgrade to next major version
+CVE-2025-67030
 
-# March 20, 2026
-# Issue with libexpat, alpine image needs to update
-CVE-2026-32767
+# July 23, 2026
+# Issue with Postgres, upgrading spring boot should help
+CVE-2026-54291

--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -24,3 +24,11 @@ CVE-2025-67030
 # July 23, 2026
 # Issue with Postgres, upgrading spring boot should help
 CVE-2026-54291
+
+# July 23, 2026
+# Issue with Netty, need to update Spring Boot
+CVE-2026-59901
+CVE-2026-55831
+CVE-2026-55833
+CVE-2026-56745
+CVE-2026-56816

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@ RUN java -Djarmode=tools -jar application.jar extract
 FROM eclipse-temurin:25-alpine
 RUN adduser --disabled-password -u 1000 java
 WORKDIR /application
-COPY --chown=java:java --from=builder application/dependencies/ ./
+COPY --chown=java:java --from=builder /builder/extracted/dependencies/ ./
 RUN true
-COPY --chown=java:java --from=builder application/spring-boot-loader/ ./
+COPY --chown=java:java --from=builder /builder/extracted/spring-boot-loader/ ./
 RUN true
-COPY --chown=java:java --from=builder application/snapshot-dependencies/ ./
+COPY --chown=java:java --from=builder /builder/extracted/snapshot-dependencies/ ./
 RUN true
-COPY --chown=java:java --from=builder application/application/ ./
+COPY --chown=java:java --from=builder /builder/extracted/application/ ./
 USER 1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:25-alpine AS builder
 WORKDIR /application
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract
 
 FROM eclipse-temurin:25-alpine
 RUN adduser --disabled-password -u 1000 java

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,18 @@ FROM eclipse-temurin:25-alpine AS builder
 WORKDIR /application
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
-RUN java -Djarmode=tools -jar application.jar extract
+RUN java -Djarmode=layertools -jar application.jar extract
 
 FROM eclipse-temurin:25-alpine
 RUN adduser --disabled-password -u 1000 java
 WORKDIR /application
-COPY --chown=java:java --from=builder /builder/extracted/dependencies/ ./
+COPY --chown=java:java --from=builder application/dependencies/ ./
 RUN true
-COPY --chown=java:java --from=builder /builder/extracted/spring-boot-loader/ ./
+COPY --chown=java:java --from=builder application/spring-boot-loader/ ./
 RUN true
-COPY --chown=java:java --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --chown=java:java --from=builder application/snapshot-dependencies/ ./
 RUN true
-COPY --chown=java:java --from=builder /builder/extracted/application/ ./
+COPY --chown=java:java --from=builder application/application/ ./
 USER 1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.3</version>
+    <version>4.1.0</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.1.0</version>
+    <version>4.0.7</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>

--- a/src/main/java/eu/dissco/core/translator/terms/specimen/LivingOrPreserved.java
+++ b/src/main/java/eu/dissco/core/translator/terms/specimen/LivingOrPreserved.java
@@ -1,8 +1,10 @@
 package eu.dissco.core.translator.terms.specimen;
 
+import lombok.extern.slf4j.Slf4j;
 import tools.jackson.databind.JsonNode;
 import eu.dissco.core.translator.terms.Term;
 
+@Slf4j
 public class LivingOrPreserved extends Term {
 
   public static final String TERM = ODS_PREFIX + "livingOrPreserved";
@@ -13,6 +15,10 @@ public class LivingOrPreserved extends Term {
   }
 
   private String determineLiving(String basisOfRecord) {
+    if (basisOfRecord == null) {
+      log.warn("Null basis of record. Unable to determine livingOrPreserved");
+      return null;
+    }
     if (basisOfRecord.toUpperCase().strip().equals("LIVINGSPECIMEN")) {
       return "Living";
     } else {

--- a/src/test/java/eu/dissco/core/translator/TestUtils.java
+++ b/src/test/java/eu/dissco/core/translator/TestUtils.java
@@ -124,7 +124,9 @@ public class TestUtils {
     return Stream.of(
         Arguments.of(new DigitalSpecimen().withOdsNormalisedPhysicalSpecimenID(
             NORMALISED_PHYSICAL_SPECIMEN_ID)),
-        Arguments.of(new DigitalSpecimen().withOdsOrganisationID(ORGANISATION_ID))
+        Arguments.of(new DigitalSpecimen().withOdsOrganisationID(ORGANISATION_ID)),
+        Arguments.of(new DigitalSpecimen().withOdsNormalisedPhysicalSpecimenID(
+            NORMALISED_PHYSICAL_SPECIMEN_ID).withOdsOrganisationID(ORGANISATION_ID))
     );
   }
 

--- a/src/test/java/eu/dissco/core/translator/terms/specimen/LivingOrPreservedTest.java
+++ b/src/test/java/eu/dissco/core/translator/terms/specimen/LivingOrPreservedTest.java
@@ -27,6 +27,18 @@ class LivingOrPreservedTest {
   }
 
   @Test
+  void testRetrieveFromDWCANullBasisOfRecord() {
+    // Given
+    var unit = MAPPER.createObjectNode();
+
+    // When
+    var result = livingSpecimen.retrieveFromDWCA(unit);
+
+    // Then
+    assertThat(result).isNull();
+  }
+
+  @Test
   void testRetrieveFromDWCANotLiving() {
     // Given
     var unit = MAPPER.createObjectNode();


### PR DESCRIPTION
[Jira](https://naturalis.atlassian.net/browse/CCD-103)

**What is this service**
The translator takes incoming dwc archives and abcd documents and transforms them into openDS, term by term. 

**What is the issue**
The term `livingOrPreserved` relied on `basisOfRecord` to determine its value. However, if `basisOfRecord` is null, this produces a null pointer exception. 

**The solution**
If `basisOfRecord` is null, `livingOrPreserved` should be null as well. This will not cause an NPE, as there are null checks for this enum. Later, the record will fail in a controlled way due to the basis of record being null. 

**AI Usage**
No AI usage